### PR TITLE
Add speaker diarization pipeline stage

### DIFF
--- a/backend/src/pipeline/engine.ts
+++ b/backend/src/pipeline/engine.ts
@@ -1,6 +1,7 @@
 import { createHttpError } from '../utils/http-error.js';
 import { ingestStep } from './steps/ingest-step.js';
 import { transcribeStep } from './steps/transcribe-step.js';
+import { diarizeStep } from './steps/diarize-step.js';
 import { summariseStep } from './steps/summarise-step.js';
 import { exportStep } from './steps/export-step.js';
 import type {
@@ -167,6 +168,7 @@ export class PipelineEngine {
     const steps: Array<{ name: string; handler: PipelineStep }> = [
       { name: 'ingest', handler: ingestStep },
       { name: 'transcribe', handler: transcribeStep },
+      { name: 'diarize', handler: diarizeStep },
       { name: 'summarise', handler: summariseStep },
       { name: 'export', handler: exportStep },
     ];

--- a/backend/src/pipeline/steps/diarize-step.ts
+++ b/backend/src/pipeline/steps/diarize-step.ts
@@ -1,0 +1,78 @@
+import path from 'node:path';
+import type { DiarizationSegment, PipelineContext, WhisperTranscriptionSegment } from '../../types/index.js';
+import { ensureDirectory } from '../../utils/fs.js';
+
+function overlaps(diarization: DiarizationSegment, segment: WhisperTranscriptionSegment): boolean {
+  const start = typeof segment.start === 'number' ? segment.start : Number.NEGATIVE_INFINITY;
+  const end = typeof segment.end === 'number' ? segment.end : Number.POSITIVE_INFINITY;
+  return diarization.end > start && diarization.start < end;
+}
+
+function assignSpeakers(
+  transcriptionSegments: WhisperTranscriptionSegment[] | undefined,
+  diarizationSegments: DiarizationSegment[],
+): void {
+  if (!Array.isArray(transcriptionSegments) || transcriptionSegments.length === 0) {
+    return;
+  }
+
+  for (const segment of transcriptionSegments) {
+    if (typeof segment.start !== 'number' && typeof segment.end !== 'number') {
+      continue;
+    }
+
+    const matches = diarizationSegments
+      .filter((item) => overlaps(item, segment))
+      .sort((a, b) => a.start - b.start);
+
+    if (matches.length === 0) {
+      continue;
+    }
+
+    segment.speaker = matches[0]?.speaker ?? null;
+    segment.diarization = matches;
+  }
+}
+
+export async function diarizeStep(context: PipelineContext): Promise<void> {
+  const { job, environment, services, jobStore, config, logger } = context;
+
+  if (!config.pipeline.enableDiarization) {
+    logger.info({ jobId: job.id }, 'Diarize step skipped because diarization disabled');
+    await jobStore.appendLog(job.id, 'Diarisation désactivée, étape ignorée');
+    context.data.diarization = [];
+    return;
+  }
+
+  const inputPath = context.data.preparedPath;
+  if (!inputPath) {
+    const message = 'Chemin audio introuvable, diarisation ignorée';
+    logger.warn({ jobId: job.id }, 'Diarize step skipped due to missing audio path');
+    await jobStore.appendLog(job.id, message, 'warn');
+    context.data.diarization = [];
+    return;
+  }
+
+  await jobStore.appendLog(job.id, 'Diarisation des locuteurs');
+
+  try {
+    const diarizationDir = path.join(environment.jobsDir, job.id, 'diarization');
+    ensureDirectory(diarizationDir);
+
+    const result = await services.diarization.diarize({ inputPath, outputDir: diarizationDir });
+    const segments = Array.isArray(result?.segments) ? result.segments : [];
+
+    context.data.diarization = segments;
+    assignSpeakers(context.data.transcription?.segments, segments);
+
+    logger.info(
+      { jobId: job.id, segmentCount: segments.length },
+      'Diarize step completed',
+    );
+    await jobStore.appendLog(job.id, 'Diarisation générée');
+  } catch (error) {
+    logger.error({ jobId: job.id, error }, 'Diarize step failed');
+    await jobStore.appendLog(job.id, "Diarisation échouée, étape ignorée", 'warn');
+    context.data.diarization = context.data.diarization ?? [];
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,6 +13,7 @@ interface ServerDependencies {
   createTemplateRepository: typeof import('./persistence/template-store.js').createTemplateRepository;
   validateEnvironment: typeof import('./utils/environment-validation.js').validateEnvironment;
   createWhisperService: typeof import('./services/whisper-service.js').createWhisperService;
+  createSpeakerDiarizationService: typeof import('./services/speaker-diarization-service.js').createSpeakerDiarizationService;
   createFfmpegService: typeof import('./services/ffmpeg-service.js').createFfmpegService;
   createOpenAiService: typeof import('./services/openai-service.js').createOpenAiService;
   createPipelineEngine: typeof import('./pipeline/engine.js').createPipelineEngine;
@@ -44,6 +45,11 @@ async function loadDependencies(
   }
   if (!dependencies.createWhisperService) {
     dependencies.createWhisperService = (await import('./services/whisper-service.js')).createWhisperService;
+  }
+  if (!dependencies.createSpeakerDiarizationService) {
+    dependencies.createSpeakerDiarizationService = (
+      await import('./services/speaker-diarization-service.js')
+    ).createSpeakerDiarizationService;
   }
   if (!dependencies.createFfmpegService) {
     dependencies.createFfmpegService = (await import('./services/ffmpeg-service.js')).createFfmpegService;
@@ -79,6 +85,7 @@ export async function createServer(
 
   const services: Services = {
     whisper: dependencies.createWhisperService(environment, { logger }),
+    diarization: dependencies.createSpeakerDiarizationService(environment, { logger }),
     ffmpeg: dependencies.createFfmpegService(environment),
     openai: dependencies.createOpenAiService({ logger, configStore }),
   };

--- a/backend/src/services/speaker-diarization-service.ts
+++ b/backend/src/services/speaker-diarization-service.ts
@@ -1,0 +1,201 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { spawn } from 'node:child_process';
+import { ensureDirectory } from '../utils/fs.js';
+import type {
+  DiarizationResult,
+  DiarizationSegment,
+  DiarizationService,
+  Environment,
+  Logger,
+} from '../types/index.js';
+
+interface CreateSpeakerDiarizationServiceOptions {
+  logger: Logger;
+}
+
+interface RunProcessOptions {
+  command: string;
+  args: string[];
+  cwd?: string;
+  logger: Logger;
+  timeout?: number;
+}
+
+function runProcess({ command, args, cwd, logger, timeout }: RunProcessOptions): Promise<{ stdout: string }>
+{
+  return new Promise((resolve, reject) => {
+    logger.info({ command, args, cwd }, 'Démarrage du processus de diarisation');
+
+    const child = spawn(command, args, { cwd });
+    let stdout = '';
+    let stderr = '';
+
+    const timer = timeout
+      ? setTimeout(() => {
+          child.kill();
+          reject(new Error(`Processus de diarisation arrêté après ${timeout}ms`));
+        }, timeout)
+      : null;
+
+    child.stdout.on('data', (chunk: unknown) => {
+      const value = typeof chunk === 'string' ? chunk : String(chunk);
+      stdout += value;
+      logger.debug({ chunk: value }, 'Sortie diarisation');
+    });
+
+    child.stderr.on('data', (chunk: unknown) => {
+      const value = typeof chunk === 'string' ? chunk : String(chunk);
+      stderr += value;
+      logger.warn({ chunk: value }, 'Erreur diarisation');
+    });
+
+    child.on('error', (error: Error) => {
+      if (timer) clearTimeout(timer);
+      reject(error);
+    });
+
+    child.on('close', (code: number | null) => {
+      if (timer) clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`Processus de diarisation terminé avec le code ${code}:\n${stderr}`));
+        return;
+      }
+
+      logger.info(
+        { stdout: stdout.substring(0, 500), stderr: stderr.substring(0, 500) },
+        'Processus de diarisation terminé avec succès',
+      );
+      resolve({ stdout });
+    });
+  });
+}
+
+function parseSegments(payload: unknown): DiarizationSegment[] {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const segmentsRaw = (payload as { segments?: unknown }).segments;
+  if (!Array.isArray(segmentsRaw)) {
+    return [];
+  }
+
+  const segments: DiarizationSegment[] = [];
+
+  for (const segment of segmentsRaw) {
+    if (!segment || typeof segment !== 'object') {
+      continue;
+    }
+
+    const { start, end, speaker } = segment as {
+      start?: unknown;
+      end?: unknown;
+      speaker?: unknown;
+    };
+
+    const parsedStart = typeof start === 'number' ? start : Number.parseFloat(String(start ?? ''));
+    const parsedEnd = typeof end === 'number' ? end : Number.parseFloat(String(end ?? ''));
+
+    if (Number.isNaN(parsedStart) || Number.isNaN(parsedEnd)) {
+      continue;
+    }
+
+    let parsedSpeaker: string = '';
+    if (typeof speaker === 'string') {
+      parsedSpeaker = speaker.trim();
+    } else if (typeof speaker === 'number') {
+      parsedSpeaker = String(speaker);
+    } else if (speaker != null) {
+      parsedSpeaker = String(speaker);
+    }
+
+    if (!parsedSpeaker) {
+      parsedSpeaker = 'Speaker';
+    }
+
+    segments.push({ start: parsedStart, end: parsedEnd, speaker: parsedSpeaker });
+  }
+
+  return segments;
+}
+
+function tryParseJson(content: string): unknown | null {
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    if (content.trim().length > 0) {
+      throw error;
+    }
+    return null;
+  }
+}
+
+export function createSpeakerDiarizationService(
+  environment: Environment,
+  { logger }: CreateSpeakerDiarizationServiceOptions,
+): DiarizationService {
+  const rootDirectory =
+    typeof environment.rootDir === 'string' && environment.rootDir.length > 0
+      ? environment.rootDir
+      : process.cwd();
+  const tmpDirectory =
+    typeof environment.tmpDir === 'string' && environment.tmpDir.length > 0
+      ? environment.tmpDir
+      : path.join(rootDirectory, 'tmp');
+
+  const pythonExecutable =
+    process.env.DIARIZATION_PYTHON_PATH || process.env.WHISPER_PYTHON_PATH || 'python3';
+  const scriptPath =
+    process.env.DIARIZATION_SCRIPT_PATH ||
+    path.join(rootDirectory, 'backend', 'tools', 'speaker-diarization.py');
+  const timeout = Number.parseInt(process.env.DIARIZATION_TIMEOUT ?? '', 10);
+
+  return {
+    async diarize({ inputPath, outputDir }): Promise<DiarizationResult> {
+      if (!inputPath) {
+        throw new Error('Chemin audio introuvable pour la diarisation');
+      }
+
+      const diarizationDir = outputDir ?? path.join(tmpDirectory, 'diarization');
+      ensureDirectory(diarizationDir);
+      const outputFile = path.join(diarizationDir, 'segments.json');
+
+      logger.info(
+        { inputPath, scriptPath, diarizationDir, outputFile },
+        'Diarization service started',
+      );
+
+      const args = [scriptPath, '--input', inputPath, '--output', outputFile];
+      if (process.env.DIARIZATION_MODEL) {
+        args.push('--model', process.env.DIARIZATION_MODEL);
+      }
+
+      const { stdout } = await runProcess({
+        command: pythonExecutable,
+        args,
+        cwd: rootDirectory,
+        logger,
+        timeout: Number.isNaN(timeout) ? undefined : timeout,
+      });
+
+      let payload: unknown | null = tryParseJson(stdout);
+
+      if ((!payload || typeof payload !== 'object') && fs.existsSync(outputFile)) {
+        const fileContent = await fs.promises.readFile(outputFile, 'utf-8');
+        payload = tryParseJson(fileContent);
+      }
+
+      if (!payload) {
+        logger.warn(
+          { inputPath, outputFile },
+          'Aucune donnée de diarisation renvoyée par le script',
+        );
+        return { segments: [] };
+      }
+
+      const segments = parseSegments(payload);
+      return { segments };
+    },
+  };
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -167,6 +167,14 @@ export interface WhisperService {
   transcribe(args: { inputPath: string; outputDir: string; config: WhisperConfig }): Promise<WhisperTranscriptionResult>;
 }
 
+export interface DiarizationResult {
+  segments: DiarizationSegment[];
+}
+
+export interface DiarizationService {
+  diarize(args: { inputPath: string; outputDir?: string }): Promise<DiarizationResult>;
+}
+
 export interface FfmpegService {
   normalizeAudio(args: { input: string; output: string }): Promise<void>;
 }
@@ -208,6 +216,7 @@ export interface TemplateStore {
 
 export type Services = {
   whisper: WhisperService;
+  diarization: DiarizationService;
   ffmpeg: FfmpegService;
   openai: OpenAiService;
 };

--- a/backend/test/pipeline-engine.test.ts
+++ b/backend/test/pipeline-engine.test.ts
@@ -55,6 +55,11 @@ test('pipeline completes job with stub services', async () => {
         };
       },
     },
+    diarization: {
+      async diarize() {
+        return { segments: [] };
+      },
+    },
     openai: {
       async generateSummary(): Promise<SummaryResult> {
         return { markdown: '# Résumé\n- Point clé' };
@@ -131,6 +136,11 @@ test('pipeline skips subtitle export when disabled in config', async () => {
           ],
           language: 'fr',
         };
+      },
+    },
+    diarization: {
+      async diarize() {
+        return { segments: [] };
       },
     },
     openai: {
@@ -215,6 +225,11 @@ test('pipeline completes job when summary generation is skipped', async () => {
         };
       },
     },
+    diarization: {
+      async diarize() {
+        return { segments: [] };
+      },
+    },
     openai: {
       async generateSummary(): Promise<SummaryResult> {
         return { markdown: null, reason: 'missing_api_key' };
@@ -292,6 +307,11 @@ test('pipeline completes job when placeholder OpenAI key is provided', async () 
         };
       },
     },
+    diarization: {
+      async diarize() {
+        return { segments: [] };
+      },
+    },
     openai: createOpenAiService({ configStore, logger }),
   };
 
@@ -367,6 +387,11 @@ test('pipeline handles job removal while queued and processing', async () => {
           ],
           language: 'fr',
         };
+      },
+    },
+    diarization: {
+      async diarize() {
+        return { segments: [] };
       },
     },
     openai: {


### PR DESCRIPTION
## Summary
- add a diarization service implementation that executes the configured script and normalises the returned segments
- register the diarization service on server start and insert a dedicated diarize step into the pipeline
- update pipeline tests to stub the new service dependency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d67612b44c8333a0819270718a4aec