### PR TITLE
feat: surface speaker diarization data in exports and UI

### DIFF
--- a/backend/src/pipeline/steps/export-step.ts
+++ b/backend/src/pipeline/steps/export-step.ts
@@ -1,6 +1,11 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import type { JobOutput, PipelineContext, WhisperTranscriptionSegment } from '../../types/index.js';
+import {
+  buildSpeakerTimeline,
+  formatTimestamp,
+  type SpeakerTimelineData,
+} from '../utils/speaker-utils.js';
 
 export async function exportStep(context: PipelineContext): Promise<void> {
   const { job, environment, jobStore, logger, config } = context;
@@ -38,11 +43,49 @@ export async function exportStep(context: PipelineContext): Promise<void> {
     );
   }
 
+  const timeline = buildSpeakerTimeline(context.data.transcription?.segments);
+
+  if (timeline) {
+    const timedTranscriptPath = path.join(jobDir, 'transcription_timed.txt');
+    await fs.promises.writeFile(timedTranscriptPath, buildTimedTranscript(timeline), 'utf8');
+    outputs.push({
+      label: 'Transcription horodatée (speakers)',
+      filename: 'transcription_timed.txt',
+      mimeType: 'text/plain',
+    });
+    logger.debug(
+      {
+        jobId: job.id,
+        timedTranscriptPath,
+        segmentCount: timeline.segments.length,
+      },
+      'Timed transcription exported',
+    );
+
+    const jsonPath = path.join(jobDir, 'segments.json');
+    await fs.promises.writeFile(jsonPath, buildSegmentsJson(timeline), 'utf8');
+    outputs.push({ label: 'Segments (JSON)', filename: 'segments.json', mimeType: 'application/json' });
+    logger.debug(
+      {
+        jobId: job.id,
+        jsonPath,
+        speakerCount: timeline.speakers.length,
+      },
+      'Speaker segments JSON exported',
+    );
+  } else {
+    logger.info({ jobId: job.id }, 'Timed transcription export skipped due to missing segments');
+  }
+
   if (config.pipeline.enableSubtitles && context.data.transcription?.segments?.length) {
     // Génération des sous-titres à la volée pour éviter d'écrire sur disque si la fonctionnalité est désactivée.
     const vttPath = path.join(jobDir, 'subtitles.vtt');
-    await fs.promises.writeFile(vttPath, buildVtt(context.data.transcription.segments), 'utf8');
-    outputs.push({ label: 'Sous-titres', filename: 'subtitles.vtt', mimeType: 'text/vtt' });
+    await fs.promises.writeFile(
+      vttPath,
+      buildVtt(context.data.transcription.segments, timeline ?? null),
+      'utf8',
+    );
+    outputs.push({ label: 'Sous-titres (avec speakers)', filename: 'subtitles.vtt', mimeType: 'text/vtt' });
     logger.debug(
       { jobId: job.id, vttPath, segmentCount: context.data.transcription.segments.length },
       'Subtitles exported',
@@ -61,24 +104,61 @@ export async function exportStep(context: PipelineContext): Promise<void> {
   await jobStore.appendLog(job.id, 'Exports finalisés');
 }
 
-function buildVtt(segments: WhisperTranscriptionSegment[]): string {
+function buildVtt(
+  segments: WhisperTranscriptionSegment[],
+  timeline: SpeakerTimelineData | null,
+): string {
   const header = 'WEBVTT\n\n';
   const body = segments
     .map((segment, index) => {
-      const start = formatTimestamp(segment.start ?? 0);
-      const end = formatTimestamp(segment.end ?? 0);
-      const text = segment.text ?? '';
-      return `${index + 1}\n${start} --> ${end}\n${text.trim()}\n`;
+      const reference = timeline?.segments[index];
+      const start = formatTimestamp(reference?.start ?? segment.start ?? 0);
+      const end = formatTimestamp(reference?.end ?? segment.end ?? 0);
+      const rawText = reference?.text ?? segment.text ?? '';
+      const speakerLabel = reference?.speakerLabel;
+      const text = speakerLabel ? `${speakerLabel}: ${rawText.trim()}` : rawText.trim();
+      return `${index + 1}\n${start} --> ${end}\n${text}\n`;
     })
     .join('\n');
   return header + body;
 }
 
-function formatTimestamp(seconds: number): string {
-  const date = new Date(seconds * 1000);
-  const hh = String(date.getUTCHours()).padStart(2, '0');
-  const mm = String(date.getUTCMinutes()).padStart(2, '0');
-  const ss = String(date.getUTCSeconds()).padStart(2, '0');
-  const ms = String(date.getUTCMilliseconds()).padStart(3, '0');
-  return `${hh}:${mm}:${ss}.${ms}`;
+function buildTimedTranscript(timeline: SpeakerTimelineData): string {
+  const header = '# Transcription horodatée\n\n';
+  const body = timeline.segments
+    .map((segment) => {
+      const start = formatTimestamp(segment.start);
+      const end = formatTimestamp(segment.end);
+      const label = segment.speakerLabel ?? 'Speaker ?';
+      const text = segment.text ? segment.text : '';
+      const suffix = text ? ` ${text}` : '';
+      return `[${start} - ${end}] ${label}:${suffix}`.trimEnd();
+    })
+    .join('\n');
+  return header + body + (body ? '\n' : '');
+}
+
+function buildSegmentsJson(timeline: SpeakerTimelineData): string {
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    segments: timeline.segments.map((segment) => ({
+      index: segment.index,
+      start: segment.start,
+      end: segment.end,
+      duration: Number.isFinite(segment.duration) ? Number(segment.duration.toFixed(3)) : 0,
+      text: segment.text,
+      speaker: segment.speakerId,
+      speakerLabel: segment.speakerLabel,
+    })),
+    speakers: timeline.speakers.map((speaker) => ({
+      id: speaker.id,
+      label: speaker.label,
+      segmentCount: speaker.segmentCount,
+      totalDuration: Number.isFinite(speaker.totalDuration)
+        ? Number(speaker.totalDuration.toFixed(3))
+        : 0,
+    })),
+  };
+
+  return `${JSON.stringify(payload, null, 2)}\n`;
 }

--- a/backend/src/pipeline/steps/summarise-step.ts
+++ b/backend/src/pipeline/steps/summarise-step.ts
@@ -1,4 +1,5 @@
 import type { PipelineContext } from '../../types/index.js';
+import { buildSpeakerTimeline, formatSpeakerOverview } from '../utils/speaker-utils.js';
 
 export async function summariseStep(context: PipelineContext): Promise<void> {
   const { job, config, template, services, jobStore, logger } = context;
@@ -21,6 +22,9 @@ export async function summariseStep(context: PipelineContext): Promise<void> {
 
   await jobStore.appendLog(job.id, 'Génération du résumé (OpenAI)');
   const { provider, model, temperature, maxOutputTokens } = config.llm;
+
+  const speakerTimeline = buildSpeakerTimeline(context.data.transcription?.segments);
+  const speakerOverview = formatSpeakerOverview(speakerTimeline?.speakers);
   logger.info(
     {
       jobId: job.id,
@@ -36,6 +40,7 @@ export async function summariseStep(context: PipelineContext): Promise<void> {
     template,
     participants: job.participants,
     config: config.llm,
+    speakerOverview: speakerOverview ?? undefined,
   });
 
   const markdown = typeof summary?.markdown === 'string' ? summary.markdown.trim() : '';

--- a/backend/src/pipeline/utils/speaker-utils.ts
+++ b/backend/src/pipeline/utils/speaker-utils.ts
@@ -1,0 +1,149 @@
+import type {
+  WhisperTranscriptionSegment,
+} from '../../types/index.js';
+
+export interface SpeakerAggregate {
+  id: string;
+  label: string;
+  segmentCount: number;
+  totalDuration: number;
+}
+
+export interface SpeakerTimelineSegment {
+  index: number;
+  start: number | null;
+  end: number | null;
+  duration: number;
+  text: string;
+  speakerId: string | null;
+  speakerLabel: string | null;
+}
+
+export interface SpeakerTimelineData {
+  segments: SpeakerTimelineSegment[];
+  speakers: SpeakerAggregate[];
+}
+
+export function buildSpeakerTimeline(
+  segments: WhisperTranscriptionSegment[] | undefined,
+): SpeakerTimelineData | null {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    return null;
+  }
+
+  const speakerOrder = new Map<string, number>();
+  const aggregates = new Map<string, SpeakerAggregate>();
+  const timeline: SpeakerTimelineSegment[] = [];
+
+  let segmentIndex = 0;
+
+  for (const segment of segments) {
+    const text = typeof segment.text === 'string' ? segment.text.trim() : '';
+    const start = typeof segment.start === 'number' ? Math.max(segment.start, 0) : null;
+    const end = typeof segment.end === 'number' ? Math.max(segment.end, 0) : null;
+    const duration = start != null && end != null && end > start ? end - start : 0;
+
+    const diarizationSpeaker = segment.diarization?.find((item) => typeof item?.speaker === 'string')?.speaker;
+    const speakerIdRaw = typeof segment.speaker === 'string' && segment.speaker.trim()
+      ? segment.speaker.trim()
+      : diarizationSpeaker && diarizationSpeaker.trim()
+        ? diarizationSpeaker.trim()
+        : null;
+
+    let speakerLabel: string | null = null;
+
+    if (speakerIdRaw) {
+      if (!speakerOrder.has(speakerIdRaw)) {
+        speakerOrder.set(speakerIdRaw, speakerOrder.size);
+      }
+      const order = speakerOrder.get(speakerIdRaw) ?? 0;
+      speakerLabel = `Speaker ${order + 1}`;
+
+      const aggregate = aggregates.get(speakerIdRaw) ?? {
+        id: speakerIdRaw,
+        label: speakerLabel,
+        segmentCount: 0,
+        totalDuration: 0,
+      };
+      aggregate.segmentCount += 1;
+      aggregate.totalDuration += duration;
+      aggregate.label = speakerLabel; // garantit la mise à jour si l'ordre change
+      aggregates.set(speakerIdRaw, aggregate);
+    }
+
+    segmentIndex += 1;
+    timeline.push({
+      index: segmentIndex,
+      start,
+      end,
+      duration,
+      text,
+      speakerId: speakerIdRaw,
+      speakerLabel,
+    });
+  }
+
+  if (timeline.every((item) => item.speakerId == null)) {
+    return {
+      segments: timeline,
+      speakers: [],
+    };
+  }
+
+  const orderedSpeakers = Array.from(aggregates.values()).sort((a, b) => {
+    const orderA = speakerOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+    const orderB = speakerOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+    return orderA - orderB;
+  });
+
+  return {
+    segments: timeline,
+    speakers: orderedSpeakers,
+  };
+}
+
+export function formatSpeakerOverview(speakers: SpeakerAggregate[] | undefined): string | null {
+  if (!Array.isArray(speakers) || speakers.length === 0) {
+    return null;
+  }
+
+  const lines = speakers.map((speaker) => {
+    const duration = formatDuration(speaker.totalDuration);
+    const plural = speaker.segmentCount > 1 ? 's' : '';
+    return `- ${speaker.label} : ${speaker.segmentCount} intervention${plural}, ${duration}`;
+  });
+
+  return `Répartition des interventions :\n${lines.join('\n')}`;
+}
+
+export function formatTimestamp(seconds: number | null | undefined): string {
+  if (typeof seconds !== 'number' || Number.isNaN(seconds) || !Number.isFinite(seconds)) {
+    return '00:00:00.000';
+  }
+  const clamped = Math.max(seconds, 0);
+  const date = new Date(clamped * 1000);
+  const hh = String(date.getUTCHours()).padStart(2, '0');
+  const mm = String(date.getUTCMinutes()).padStart(2, '0');
+  const ss = String(date.getUTCSeconds()).padStart(2, '0');
+  const ms = String(date.getUTCMilliseconds()).padStart(3, '0');
+  return `${hh}:${mm}:${ss}.${ms}`;
+}
+
+export function formatDuration(seconds: number | null | undefined): string {
+  if (typeof seconds !== 'number' || Number.isNaN(seconds) || !Number.isFinite(seconds)) {
+    return '0s';
+  }
+
+  const totalSeconds = Math.max(Math.round(seconds), 0);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${secs}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${secs}s`;
+  }
+  return `${secs}s`;
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -185,6 +185,7 @@ export interface OpenAiService {
     template: Template;
     participants: string[];
     config: LlmConfig;
+    speakerOverview?: string;
   }): Promise<SummaryResult>;
 }
 

--- a/backend/test/pipeline-engine.test.ts
+++ b/backend/test/pipeline-engine.test.ts
@@ -61,7 +61,7 @@ test('pipeline completes job with stub services', async () => {
       },
     },
     openai: {
-      async generateSummary(): Promise<SummaryResult> {
+      async generateSummary(_args?: unknown): Promise<SummaryResult> {
         return { markdown: '# Résumé\n- Point clé' };
       },
     },
@@ -94,13 +94,17 @@ test('pipeline completes job with stub services', async () => {
   }, 10_000);
 
   assert.equal(finalJob?.status, 'completed');
-  assert.equal(finalJob?.outputs.length, 3);
+  assert.equal(finalJob?.outputs.length, 5);
 
   const transcriptPath = path.join(environment.jobsDir, job.id, 'transcription_raw.txt');
+  const timedTranscriptPath = path.join(environment.jobsDir, job.id, 'transcription_timed.txt');
+  const segmentsJsonPath = path.join(environment.jobsDir, job.id, 'segments.json');
   const summaryPath = path.join(environment.jobsDir, job.id, 'summary.md');
   const subtitlesPath = path.join(environment.jobsDir, job.id, 'subtitles.vtt');
 
   assert.ok(fs.existsSync(transcriptPath));
+  assert.ok(fs.existsSync(timedTranscriptPath));
+  assert.ok(fs.existsSync(segmentsJsonPath));
   assert.ok(fs.existsSync(summaryPath));
   assert.ok(fs.existsSync(subtitlesPath));
 });
@@ -144,7 +148,7 @@ test('pipeline skips subtitle export when disabled in config', async () => {
       },
     },
     openai: {
-      async generateSummary(): Promise<SummaryResult> {
+      async generateSummary(_args?: unknown): Promise<SummaryResult> {
         return { markdown: '# Résumé\n- Point clé' };
       },
     },
@@ -177,17 +181,21 @@ test('pipeline skips subtitle export when disabled in config', async () => {
   }, 10_000);
 
   assert.equal(finalJob?.status, 'completed');
-  assert.equal(finalJob?.outputs.length, 2);
+  assert.equal(finalJob?.outputs.length, 4);
   assert.deepEqual(
     (finalJob?.outputs.map((output) => output.filename).sort() ?? []),
-    ['summary.md', 'transcription_raw.txt'],
+    ['segments.json', 'summary.md', 'transcription_raw.txt', 'transcription_timed.txt'],
   );
 
   const transcriptPath = path.join(environment.jobsDir, job.id, 'transcription_raw.txt');
+  const timedTranscriptPath = path.join(environment.jobsDir, job.id, 'transcription_timed.txt');
+  const segmentsJsonPath = path.join(environment.jobsDir, job.id, 'segments.json');
   const summaryPath = path.join(environment.jobsDir, job.id, 'summary.md');
   const subtitlesPath = path.join(environment.jobsDir, job.id, 'subtitles.vtt');
 
   assert.ok(fs.existsSync(transcriptPath));
+  assert.ok(fs.existsSync(timedTranscriptPath));
+  assert.ok(fs.existsSync(segmentsJsonPath));
   assert.ok(fs.existsSync(summaryPath));
   assert.ok(!fs.existsSync(subtitlesPath));
 
@@ -231,7 +239,7 @@ test('pipeline completes job when summary generation is skipped', async () => {
       },
     },
     openai: {
-      async generateSummary(): Promise<SummaryResult> {
+      async generateSummary(_args?: unknown): Promise<SummaryResult> {
         return { markdown: null, reason: 'missing_api_key' };
       },
     },
@@ -264,7 +272,7 @@ test('pipeline completes job when summary generation is skipped', async () => {
   }, 10_000);
 
   assert.equal(finalJob?.status, 'completed');
-  assert.equal(finalJob?.outputs.length, 2);
+  assert.equal(finalJob?.outputs.length, 4);
 
   const summaryPath = path.join(environment.jobsDir, job.id, 'summary.md');
   assert.ok(!fs.existsSync(summaryPath));
@@ -342,7 +350,7 @@ test('pipeline completes job when placeholder OpenAI key is provided', async () 
   }, 10_000);
 
   assert.equal(finalJob?.status, 'completed');
-  assert.equal(finalJob?.outputs.length, 2);
+  assert.equal(finalJob?.outputs.length, 4);
 
   const summaryPath = path.join(environment.jobsDir, job.id, 'summary.md');
   assert.ok(!fs.existsSync(summaryPath));

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -472,6 +472,86 @@ textarea.large {
   gap: 2rem;
 }
 
+.text-error {
+  color: #fca5a5;
+}
+
+.speaker-section {
+  display: grid;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.speaker-stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.speaker-stats li {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.9rem;
+}
+
+.speaker-stats .label {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.speaker-stats .meta {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.segment-timeline {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.segment-row {
+  display: grid;
+  grid-template-columns: minmax(110px, auto) minmax(110px, auto) 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.9rem;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  padding: 0.75rem 1rem;
+}
+
+.segment-row .time-range {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.segment-row .speaker-label {
+  font-weight: 600;
+  color: #cbd5f5;
+}
+
+.segment-row .segment-text {
+  color: #e2e8f0;
+  line-height: 1.4;
+}
+
+@media (max-width: 768px) {
+  .segment-row {
+    grid-template-columns: 1fr;
+  }
+
+  .segment-row .speaker-label {
+    margin-top: -0.25rem;
+  }
+}
+
 .asset-meta {
   font-size: 0.75rem;
   color: #94a3b8;


### PR DESCRIPTION
## Summary
- add speaker timeline utilities and feed the overview into LLM summary prompts
- export timed transcripts, segment JSON, and speaker-prefixed VTT files alongside existing assets
- surface speaker statistics and a segment timeline in the job detail UI with supporting styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d67966a5388333bd30a1f147d7c425