### PR TITLE
Add diarization documentation and extend pipeline coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ npm run dev
 - Interface sur `http://localhost:5173`
 - L'URL backend est déterminée via `VITE_BACKEND_URL` ; à défaut, le port 4000 est utilisé par défaut
 
+### Activer la diarisation des locuteurs
+
+Le pipeline peut enrichir la transcription avec l'identité des intervenants lorsqu'un script Python de diarisation est disponible.
+
+1. Installez les dépendances nécessaires (PyTorch + bibliothèque de diarisation de votre choix) dans un environnement Python dédié et exposez un script compatible avec l'API `speaker-diarization.py` (arguments `--input` et `--output` produisant un fichier JSON de segments).
+2. Renseignez les variables d'environnement côté backend :
+   - `DIARIZATION_PYTHON_PATH` : exécutable Python à utiliser (`python`, `python3`, chemin virtuel, …) ;
+   - `DIARIZATION_SCRIPT_PATH` : chemin absolu du script de diarisation si vous n'utilisez pas l'emplacement par défaut `backend/tools/speaker-diarization.py` ;
+   - `DIARIZATION_MODEL` (optionnel) : identifiant de modèle transmis au script ;
+   - `DIARIZATION_TIMEOUT` (optionnel) : durée maximale d'exécution en millisecondes.
+3. Activez le flag **Activer la diarisation des locuteurs** depuis l'onglet Configuration du frontend (ou en modifiant `config.json` via l'API).
+
+Le guide détaillé (prérequis Python, format JSON attendu, conseils de mise en production) est disponible dans `docs/DIARIZATION.md`.
+
 ## Scripts & packaging
 
 | Commande | Description |

--- a/backend/test/speaker-diarization-service.test.ts
+++ b/backend/test/speaker-diarization-service.test.ts
@@ -1,0 +1,156 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import { createSpeakerDiarizationService } from '../src/services/speaker-diarization-service.js';
+import type { Environment, Logger } from '../src/types/index.js';
+
+interface MockChildProcess extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: () => boolean;
+}
+
+function createTempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cr-automatique-diarization-test-'));
+}
+
+function createEnvironment(rootDir: string): Environment {
+  const jobsDir = path.join(rootDir, 'jobs');
+  const uploadsDir = path.join(rootDir, 'uploads');
+  const tmpDir = path.join(rootDir, 'tmp');
+  fs.mkdirSync(jobsDir, { recursive: true });
+  fs.mkdirSync(uploadsDir, { recursive: true });
+  fs.mkdirSync(tmpDir, { recursive: true });
+  return {
+    rootDir,
+    jobsDir,
+    uploadsDir,
+    tmpDir,
+    configFile: path.join(rootDir, 'config.json'),
+    templatesFile: path.join(rootDir, 'templates.json'),
+    jobsFile: path.join(rootDir, 'jobs.json'),
+    whisperBinary: null,
+    ffmpegBinary: null,
+  };
+}
+
+function createLogger(): Logger {
+  return {
+    info() {},
+    error() {},
+    warn() {},
+    debug() {},
+  };
+}
+
+function createMockProcess({
+  onStart,
+  killImpl,
+}: {
+  onStart?: (child: MockChildProcess) => void;
+  killImpl?: () => boolean;
+} = {}): MockChildProcess {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const child = new EventEmitter() as MockChildProcess;
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.kill = killImpl || (() => true);
+  if (onStart) {
+    onStart(child);
+  }
+  return child;
+}
+
+test('speaker diarization service returns parsed segments from stdout', async () => {
+  const rootDir = createTempRoot();
+  const environment = createEnvironment(rootDir);
+  const logger = createLogger();
+  const inputPath = path.join(rootDir, 'input.wav');
+  await fs.promises.writeFile(inputPath, 'fake-audio');
+
+  const spawnCalls: Array<{ command: string; args: string[] }> = [];
+
+  const service = createSpeakerDiarizationService(environment, {
+    logger,
+    spawn: (command, args) => {
+      const argList = Array.isArray(args) ? [...args] : [];
+      spawnCalls.push({ command, args: argList });
+      const child = createMockProcess();
+      setImmediate(() => {
+        child.stdout.emit(
+          'data',
+          JSON.stringify({ segments: [{ start: 0, end: 1.2, speaker: 'alpha' }] }),
+        );
+        child.emit('close', 0);
+      });
+      return child;
+    },
+  });
+
+  const result = await service.diarize({ inputPath, outputDir: path.join(rootDir, 'out') });
+
+  assert.deepEqual(result.segments, [{ start: 0, end: 1.2, speaker: 'alpha' }]);
+  assert.equal(spawnCalls.length, 1);
+  assert.ok(spawnCalls[0]?.args.includes('--input'));
+  assert.ok(spawnCalls[0]?.args.includes('--output'));
+});
+
+test('speaker diarization service rejects when process exits with error', async () => {
+  const rootDir = createTempRoot();
+  const environment = createEnvironment(rootDir);
+  const logger = createLogger();
+  const inputPath = path.join(rootDir, 'input.wav');
+  await fs.promises.writeFile(inputPath, 'fake-audio');
+
+  const service = createSpeakerDiarizationService(environment, {
+    logger,
+    spawn: () => {
+      const child = createMockProcess();
+      setImmediate(() => {
+        child.stderr.emit('data', 'boom');
+        child.emit('close', 2);
+      });
+      return child;
+    },
+  });
+
+  await assert.rejects(
+    service.diarize({ inputPath, outputDir: path.join(rootDir, 'out') }),
+    /code 2/,
+  );
+});
+
+test('speaker diarization service aborts when timeout is reached', async () => {
+  const rootDir = createTempRoot();
+  const environment = createEnvironment(rootDir);
+  const logger = createLogger();
+  const inputPath = path.join(rootDir, 'input.wav');
+  await fs.promises.writeFile(inputPath, 'fake-audio');
+
+  process.env.DIARIZATION_TIMEOUT = '25';
+
+  let killed = false;
+
+  const service = createSpeakerDiarizationService(environment, {
+    logger,
+    spawn: () =>
+      createMockProcess({
+        killImpl: () => {
+          killed = true;
+          return true;
+        },
+      }),
+  });
+
+  await assert.rejects(
+    service.diarize({ inputPath, outputDir: path.join(rootDir, 'out') }),
+    /arrêté après 25ms/,
+  );
+
+  assert.equal(killed, true);
+  delete process.env.DIARIZATION_TIMEOUT;
+});

--- a/docs/DIARIZATION.md
+++ b/docs/DIARIZATION.md
@@ -1,0 +1,61 @@
+# Diarisation des locuteurs
+
+La diarisation permet d'associer chaque segment de la transcription à un intervenant identifié. Dans CR Automatique 2, cette fonctionnalité repose sur un script Python externe exécuté via le service `speaker-diarization-service`.
+
+## Dépendances requises
+
+- **Python 3.9+** (la version doit être compatible avec vos bibliothèques audio).
+- **PyTorch** avec l'accélération adaptée à votre machine (CPU ou GPU).
+- Une bibliothèque de diarisation telle que :
+  - [`pyannote.audio`](https://github.com/pyannote/pyannote-audio) : modèles pré-entraînés open source, nécessite un compte Hugging Face ;
+  - [`whisperx`](https://github.com/m-bain/whisperX) : pipeline complet transcription + diarisation, exploitable en mode hors-ligne ;
+  - tout autre outil capable de produire un fichier JSON de segments.
+- Les dépendances système associées (FFmpeg, bibliothèques CUDA/cuDNN si vous ciblez le GPU, etc.).
+
+> Astuce : placez ces dépendances dans un environnement virtuel dédié (`python -m venv .venv && source .venv/bin/activate`) afin d'éviter les conflits avec Whisper.
+
+## Script attendu
+
+Le service Node.js invoque un script conforme à la convention suivante :
+
+```bash
+python speaker-diarization.py --input <fichier-audio> --output <fichier-json> [--model <identifiant>]
+```
+
+Le script doit écrire sur la sortie standard (stdout) **et/ou** dans le fichier JSON passé via `--output` un objet contenant un tableau `segments`. Exemple minimal :
+
+```json
+{
+  "segments": [
+    { "start": 0.0, "end": 5.4, "speaker": "speaker_0" },
+    { "start": 5.4, "end": 9.8, "speaker": "speaker_1" }
+  ]
+}
+```
+
+Chaque segment doit respecter les règles suivantes :
+
+- `start` et `end` sont exprimés en secondes (nombre flottant) ;
+- `speaker` identifie l'intervenant (chaîne de caractères) ;
+- les segments peuvent se chevaucher, ils sont ensuite filtrés côté Node.js pour déterminer la meilleure correspondance.
+
+Déposez votre script dans `backend/tools/speaker-diarization.py` ou personnalisez le chemin via `DIARIZATION_SCRIPT_PATH`.
+
+## Variables d'environnement
+
+| Variable | Description |
+| --- | --- |
+| `DIARIZATION_PYTHON_PATH` | Exécutable Python utilisé pour lancer le script (`python`, `python3`, `/opt/env/bin/python`, …). |
+| `DIARIZATION_SCRIPT_PATH` | (Optionnel) Chemin absolu du script si vous ne conservez pas l'emplacement par défaut. |
+| `DIARIZATION_MODEL` | (Optionnel) Identifiant de modèle transmis tel quel au script (`--model`). |
+| `DIARIZATION_TIMEOUT` | (Optionnel) Timeout en millisecondes avant arrêt forcé du processus Python. |
+
+Pensez à redémarrer le backend après modification de ces variables.
+
+## Activation côté application
+
+1. **Configuration backend** : assurez-vous que les variables ci-dessus sont définies et que le script répond correctement lorsque vous l'exécutez manuellement.
+2. **UI / config.json** : activez le booléen `enableDiarization` depuis le panneau *Configuration → Options du pipeline* (checkbox « Activer la diarisation des locuteurs ») ou en éditant `config.json` via l'API REST.
+3. **Validation** : soumettez un job de test et vérifiez que `segments.json`, `transcription_timed.txt` et `subtitles.vtt` contiennent bien des étiquettes « Speaker X ».
+
+En cas d'échec, consultez les logs du job (backend) : un avertissement « Diarisation échouée, étape ignorée » signifie que le script a retourné un code non nul ou un JSON invalide. Ajustez alors vos dépendances ou augmentez `DIARIZATION_TIMEOUT`.


### PR DESCRIPTION
## Summary
- extend pipeline integration tests to cover diarization toggles and speaker labels
- allow overriding the diarization process spawner and add focused service tests for success/error/timeout cases
- document diarization requirements and activation steps for the backend and UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d67c3901dc8333908b6d86edc75c07