### PR TITLE
Update backend VS Code launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,11 +4,18 @@
     {
       "name": "Attach Node: Backend (nodemon)",
       "type": "node",
-      "request": "attach",
-      "port": 9229,
-      "restart": true,
-      "protocol": "inspector",
-      "timeout": 30000
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
+      "cwd": "${workspaceFolder}/backend",
+      "env": {
+        "NODE_OPTIONS": "--inspect"
+      },
+      "envFile": "${workspaceFolder}/backend/.env",
+      "console": "integratedTerminal"
     },
     {
       "name": "Brave: Vite UI",


### PR DESCRIPTION
## Summary
- replace the backend attach configuration with a launch configuration that starts `npm run dev`
- configure the environment to load `.env`, set `NODE_OPTIONS`, and run in the integrated terminal for debugging

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d685f66ff483339a2fa2e0c87606c1