### PR TITLE
Configure VS Code dev tasks for parallel backend/frontend launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
   "compounds": [
     {
       "name": "CRAuto: dev (backend+frontend)",
-      "preLaunchTask": "Backend: npm install",
+      "preLaunchTask": "Dev: backend+frontend",
       "configurations": [
         "Attach Node: Backend (nodemon)",
         "Brave: Vite UI"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,13 +17,20 @@
       "label": "Backend: dev",
       "type": "npm",
       "script": "dev",
-      "path": "backend"
+      "path": "backend",
+      "isBackground": true
     },
     {
       "label": "Frontend: dev",
       "type": "npm",
       "script": "dev",
-      "path": "frontend"
+      "path": "frontend",
+      "isBackground": true
+    },
+    {
+      "label": "Dev: backend+frontend",
+      "dependsOn": ["Backend: dev", "Frontend: dev"],
+      "dependsOrder": "parallel"
     },
     {
       "label": "Backend: test",


### PR DESCRIPTION
## Summary
- mark the backend and frontend dev npm tasks as background processes
- add a composite task that starts both dev servers in parallel
- update the compound launch configuration to depend on the new composite task

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6867c8944833393d909610bfc5629