### PR TITLE
Update Brave launch preLaunchTask

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,7 @@
       "runtimeExecutable": "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
       "userDataDir": "${workspaceFolder}/.vscode/.brave-debug-profile",
       "runtimeArgs": ["--auto-open-devtools-for-tabs"],
-      "preLaunchTask": "Frontend: dev",
+      "preLaunchTask": "Dev: backend+frontend",
       "trace": true
     }
   ],


### PR DESCRIPTION
## Summary
- update the Brave Vite UI launch configuration to use the combined backend+frontend task so both servers start before the browser opens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d69544c39c83339103ee7fa56c3fb1