### PR TITLE
Improve template manager responsiveness

### DIFF
--- a/frontend/src/components/TemplateManager.jsx
+++ b/frontend/src/components/TemplateManager.jsx
@@ -77,6 +77,11 @@ export default function TemplateManager({ templates, onCreate, onUpdate, onDelet
       </form>
 
       <div className="template-grid">
+        <div className="template-grid-header" aria-hidden="true">
+          <span>Nom</span>
+          <span>Description</span>
+          <span>Actions</span>
+        </div>
         {sortedTemplates.map((template) => (
           <TemplateCard
             key={template.id}
@@ -115,7 +120,7 @@ function TemplateCard({ template, isEditing, onEdit, onCancel, onDelete, onSave 
 
   if (isEditing) {
     return (
-      <form className="template-card" onSubmit={handleSubmit}>
+      <form className="template-card template-card--edit" onSubmit={handleSubmit}>
         <div className="input-group">
           <label htmlFor={`name-${template.id}`}>Nom</label>
           <input
@@ -156,12 +161,9 @@ function TemplateCard({ template, isEditing, onEdit, onCancel, onDelete, onSave 
   }
 
   return (
-    <article className="template-card">
-      <header>
-        <h3>{template.name}</h3>
-        <p className="job-meta">{template.description || 'Pas de description'}</p>
-      </header>
-      <pre className="prompt-preview">{template.prompt}</pre>
+    <article className="template-card template-card--view">
+      <h3 className="template-name">{template.name}</h3>
+      <p className="template-description job-meta">{template.description || 'Pas de description'}</p>
       <div className="template-actions">
         <button className="button secondary" type="button" onClick={onEdit}>
           Modifier
@@ -170,6 +172,7 @@ function TemplateCard({ template, isEditing, onEdit, onCancel, onDelete, onSave 
           Supprimer
         </button>
       </div>
+      <pre className="prompt-preview">{template.prompt}</pre>
     </article>
   );
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -383,7 +383,10 @@
 .template-grid {
   display: grid;
   gap: 1.25rem;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+.template-grid-header {
+  display: none;
 }
 
 .template-card {
@@ -398,6 +401,7 @@
 .template-actions {
   display: flex;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 textarea.large {
@@ -609,6 +613,31 @@ legend {
   gap: 2rem;
 }
 
+.template-card--view {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.template-card--view .template-name {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.template-card--view .template-description {
+  margin: 0;
+}
+
+.template-card--view .template-actions {
+  justify-content: flex-start;
+}
+
+.template-card--view .prompt-preview {
+  margin-top: 0.5rem;
+}
+
+.template-card--edit {
+  gap: 1.25rem;
+}
+
 .prompt-preview {
   background: rgba(15, 23, 42, 0.6);
   border-radius: 0.9rem;
@@ -631,4 +660,60 @@ legend {
   padding: 1.5rem;
   display: grid;
   gap: 1rem;
+}
+
+@media (min-width: 900px) {
+  .template-grid {
+    gap: 1rem;
+  }
+
+  .template-grid-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 2fr) minmax(0, 1fr);
+    padding: 0 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #94a3b8;
+  }
+
+  .template-card--view {
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 2fr) minmax(0, 1fr);
+    grid-template-areas:
+      'name description actions'
+      'prompt prompt prompt';
+    align-items: start;
+  }
+
+  .template-card--view .template-name {
+    grid-area: name;
+    font-size: 1.15rem;
+  }
+
+  .template-card--view .template-description {
+    grid-area: description;
+  }
+
+  .template-card--view .template-actions {
+    grid-area: actions;
+    justify-content: flex-end;
+  }
+
+  .template-card--view .prompt-preview {
+    grid-area: prompt;
+    margin-top: 0;
+  }
+
+  .template-card--edit {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .template-card--edit .input-group:nth-last-child(2) {
+    grid-column: span 2;
+  }
+
+  .template-card--edit .template-actions {
+    justify-content: flex-end;
+  }
 }


### PR DESCRIPTION
## Summary
- restructure the template manager layout to expose header columns and clearer markup for view and edit states
- update styling to provide responsive column layout on wide screens while keeping stacked cards on mobile and allowing actions to wrap

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6b0246ffc8333a9a88383b9bb6291