### PR TITLE
Refactor template manager UI with table layout

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -29,3 +29,119 @@
     flex: 1 1 auto;
   }
 }
+
+.template-manager-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.template-form,
+.template-editor {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.template-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+
+.template-table th,
+.template-table td {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+  vertical-align: top;
+}
+
+.template-table th {
+  text-align: left;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  background: var(--color-app-bg);
+}
+
+.template-table th.template-actions {
+  text-align: right;
+}
+
+.template-table tr:last-child td {
+  border-bottom: none;
+}
+
+.template-table tr.is-editing {
+  background: var(--color-app-bg);
+}
+
+.template-table .template-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.template-table .template-prompt-preview pre {
+  margin: 0;
+  max-height: 9rem;
+  overflow-y: auto;
+  background: transparent;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+}
+
+.template-empty {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 768px) {
+  .template-table thead {
+    display: none;
+  }
+
+  .template-table tr {
+    display: block;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+
+  .template-table tr:last-child {
+    border-bottom: none;
+  }
+
+  .template-table td {
+    display: grid;
+    grid-template-columns: 8rem 1fr;
+    gap: 0.75rem;
+    border: none;
+    padding: 0.85rem 1rem;
+  }
+
+  .template-table td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    color: var(--color-text-muted);
+  }
+
+  .template-table .template-actions {
+    justify-content: flex-start;
+  }
+
+  .template-table td.template-empty {
+    display: block;
+    padding: 1.5rem 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add an `isCreating` toggle and conditional creation form to the template manager
- replace the template card grid with a sortable table and dedicated edit panel
- add responsive styles for the new table and editor layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6bcaa50e08333aa2764f0e1d50076