### PR TITLE
Add router-based job history pages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
         "@types/react": "^18.2.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@types/react": "^18.2.21",

--- a/frontend/src/context/AppContext.jsx
+++ b/frontend/src/context/AppContext.jsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { api } from '../api/client.js';
 
 const AppContext = createContext(null);
 
@@ -6,6 +7,51 @@ export function AppProvider({ children }) {
   const [config, setConfig] = useState(null);
   const [templates, setTemplates] = useState([]);
   const [jobs, setJobs] = useState([]);
+  const [isJobsLoading, setIsJobsLoading] = useState(true);
+  const [jobsError, setJobsError] = useState(null);
+
+  const refreshJobs = useCallback(async () => {
+    try {
+      const jobList = await api.listJobs();
+      setJobs(jobList);
+      setJobsError(null);
+      setIsJobsLoading(false);
+      return jobList;
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error('Impossible de récupérer les traitements');
+      setJobsError(err.message);
+      setIsJobsLoading(false);
+      throw err;
+    }
+  }, []);
+
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId;
+
+    const poll = async () => {
+      try {
+        await refreshJobs();
+      } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.error('Échec du rafraîchissement des traitements', error);
+        }
+      } finally {
+        if (!isActive) return;
+        timeoutId = setTimeout(poll, 4000);
+      }
+    };
+
+    poll();
+
+    return () => {
+      isActive = false;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [refreshJobs]);
 
   const value = useMemo(
     () => ({
@@ -14,9 +60,11 @@ export function AppProvider({ children }) {
       templates,
       setTemplates,
       jobs,
-      setJobs,
+      isJobsLoading,
+      jobsError,
+      refreshJobs,
     }),
-    [config, templates, jobs],
+    [config, templates, jobs, isJobsLoading, jobsError, refreshJobs],
   );
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import './styles/global.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/HistoryListPage.jsx
+++ b/frontend/src/pages/HistoryListPage.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import JobList from '../components/JobList.jsx';
+
+export default function HistoryListPage({ jobs, isLoading, error, onDeleteJob }) {
+  const navigate = useNavigate();
+
+  const handleSelectJob = (jobId) => {
+    navigate(`/historique/${jobId}`);
+  };
+
+  const subtitle = isLoading
+    ? 'Chargement des traitements…'
+    : `${jobs.length} traitement(s) enregistré(s)`;
+
+  return (
+    <section className="surface-card space-y-4">
+      <div>
+        <h2 className="section-title">Historique des traitements</h2>
+        <p className="text-base-content/70 text-sm">{subtitle}</p>
+      </div>
+      {error && (
+        <div role="alert" className="alert alert--error">
+          {error}
+        </div>
+      )}
+      {isLoading ? (
+        <p className="text-base-content/70">Chargement en cours…</p>
+      ) : (
+        <JobList jobs={jobs} selectedJob={null} onSelect={handleSelectJob} onDelete={onDeleteJob} />
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/JobDetailPage.jsx
+++ b/frontend/src/pages/JobDetailPage.jsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import JobDetail from '../components/JobDetail.jsx';
+import { api } from '../api/client.js';
+
+export default function JobDetailPage({ jobsError = null }) {
+  const { jobId } = useParams();
+  const navigate = useNavigate();
+  const [job, setJob] = useState(null);
+  const [jobError, setJobError] = useState(null);
+  const [isLoadingJob, setIsLoadingJob] = useState(true);
+  const [logs, setLogs] = useState([]);
+  const [isLoadingLogs, setIsLoadingLogs] = useState(false);
+
+  useEffect(() => {
+    if (!jobId) {
+      setJob(null);
+      setJobError("Aucun traitement sélectionné.");
+      setIsLoadingJob(false);
+      return undefined;
+    }
+
+    let isActive = true;
+    let isFetching = false;
+    setIsLoadingJob(true);
+    setJobError(null);
+
+    const fetchJob = async () => {
+      if (isFetching) return;
+      isFetching = true;
+      try {
+        const details = await api.getJob(jobId);
+        if (!isActive) return;
+        setJob(details);
+      } catch (error) {
+        if (!isActive) return;
+        const message = error instanceof Error ? error.message : 'Erreur inconnue';
+        setJob(null);
+        setJobError(`Impossible de charger ce traitement : ${message}`);
+      } finally {
+        if (isActive) {
+          setIsLoadingJob(false);
+        }
+        isFetching = false;
+      }
+    };
+
+    fetchJob();
+    const intervalId = setInterval(fetchJob, 5000);
+
+    return () => {
+      isActive = false;
+      clearInterval(intervalId);
+    };
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!jobId) {
+      setLogs([]);
+      setIsLoadingLogs(false);
+      return undefined;
+    }
+
+    let isActive = true;
+    let isFetchingLogs = false;
+
+    const fetchLogs = async () => {
+      if (isFetchingLogs) return;
+      isFetchingLogs = true;
+      setIsLoadingLogs(true);
+      try {
+        const entries = await api.getJobLogs(jobId);
+        if (isActive) {
+          setLogs(entries);
+        }
+      } catch (error) {
+        if (isActive) {
+          const message = error instanceof Error ? error.message : 'Erreur inconnue';
+          setLogs([
+            {
+              message: `Impossible de charger le journal : ${message}`,
+              level: 'error',
+              timestamp: new Date().toISOString(),
+            },
+          ]);
+        }
+      } finally {
+        if (isActive) {
+          setIsLoadingLogs(false);
+        }
+        isFetchingLogs = false;
+      }
+    };
+
+    setLogs([]);
+    fetchLogs();
+    const intervalId = setInterval(fetchLogs, 5000);
+
+    return () => {
+      isActive = false;
+      clearInterval(intervalId);
+    };
+  }, [jobId]);
+
+  return (
+    <div className="space-y-6">
+      <button
+        type="button"
+        className="btn btn-secondary btn-sm"
+        onClick={() => navigate('/historique')}
+      >
+        ← Retour à l'historique
+      </button>
+      {jobsError && (
+        <div role="alert" className="alert alert--error">
+          {jobsError}
+        </div>
+      )}
+      <div className="surface-card">
+        {isLoadingJob ? (
+          <p className="text-base-content/70">Chargement du traitement…</p>
+        ) : jobError ? (
+          <div className="space-y-4">
+            <p className="text-base-content/70">{jobError}</p>
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              onClick={() => navigate('/historique')}
+            >
+              Retour à l'historique
+            </button>
+          </div>
+        ) : (
+          <JobDetail job={job} logs={logs} isLoadingLogs={isLoadingLogs} />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add react-router-dom and switch the entry point to BrowserRouter/Routes navigation
- split the history into dedicated list and detail pages while reusing existing JobDetail
- centralize job list polling inside the app context so history views share refresh logic

## Testing
- npm run build *(fails: react-router-dom package cannot be downloaded in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e959657c83338940eb317909051c