### PR TITLE
Simplify job history table interactions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -71,20 +71,6 @@ function AppShell() {
     }
   };
 
-  const handleDeleteJob = async (jobId) => {
-    setError(null);
-    try {
-      await api.deleteJob(jobId);
-      const refreshed = await api.listJobs();
-      setJobs(refreshed);
-      if (selectedJobId === jobId) {
-        setSelectedJobId(refreshed[0]?.id || null);
-      }
-    } catch (err) {
-      setError(err.message);
-    }
-  };
-
   const handleSelectJob = (jobId) => {
     setSelectedJobId(jobId);
     setActiveTab('jobs');
@@ -169,12 +155,7 @@ function AppShell() {
         <main className="space-y-8">
           {activeTab === 'upload' && <UploadForm templates={templates} onSubmit={handleUpload} />}
           {activeTab === 'jobs' && (
-            <JobDashboard
-              jobs={jobs}
-              selectedJob={selectedJob}
-              onSelectJob={handleSelectJob}
-              onDeleteJob={handleDeleteJob}
-            />
+            <JobDashboard jobs={jobs} selectedJob={selectedJob} onSelectJob={handleSelectJob} />
           )}
           {activeTab === 'config' && config && (
             <ConfigPanel config={config} onSave={handleSaveConfig} />

--- a/frontend/src/components/JobDashboard.jsx
+++ b/frontend/src/components/JobDashboard.jsx
@@ -3,7 +3,7 @@ import JobList from './JobList.jsx';
 import JobDetail from './JobDetail.jsx';
 import { api } from '../api/client.js';
 
-export default function JobDashboard({ jobs, selectedJob, onSelectJob, onDeleteJob }) {
+export default function JobDashboard({ jobs, selectedJob, onSelectJob }) {
   const [logs, setLogs] = useState([]);
   const [isLoadingLogs, setIsLoadingLogs] = useState(false);
 
@@ -41,7 +41,7 @@ export default function JobDashboard({ jobs, selectedJob, onSelectJob, onDeleteJ
           <h2 className="section-title">Historique des traitements</h2>
           <p className="text-base-content/70 text-sm">{jobs.length} traitement(s) enregistré(s)</p>
         </div>
-        <JobList jobs={jobs} selectedJob={selectedJob} onSelect={onSelectJob} onDelete={onDeleteJob} />
+        <JobList jobs={jobs} selectedJob={selectedJob} onSelect={onSelectJob} />
       </div>
       <div className="surface-card">
         <JobDetail job={selectedJob} logs={logs} isLoadingLogs={isLoadingLogs} />

--- a/frontend/src/components/JobList.jsx
+++ b/frontend/src/components/JobList.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import StatusBadge from './StatusBadge.jsx';
 
-export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
+export default function JobList({ jobs, selectedJob, onSelect }) {
+  const handleSelect = (jobId) => {
+    if (onSelect) {
+      onSelect(jobId);
+    }
+  };
+
   if (!jobs.length) {
     return <p className="history-empty">Aucun traitement pour le moment.</p>;
   }
@@ -14,9 +20,6 @@ export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
             <th scope="col">Fichier</th>
             <th scope="col">Statut</th>
             <th scope="col">Progression</th>
-            <th scope="col" className="text-right">
-              Actions
-            </th>
           </tr>
         </thead>
         <tbody>
@@ -27,7 +30,15 @@ export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
               <tr
                 key={job.id}
                 className={isActive ? 'history-row--active' : undefined}
-                onClick={() => onSelect(job.id)}
+                role="link"
+                tabIndex={0}
+                onClick={() => handleSelect(job.id)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    handleSelect(job.id);
+                  }
+                }}
               >
                 <td>
                   <div className="font-medium">{job.filename}</div>
@@ -45,30 +56,6 @@ export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
                       <div className="progress-bar__value" style={{ width: `${progressValue}%` }} />
                     </div>
                     <span className="status-progress-value">{progressValue}%</span>
-                  </div>
-                </td>
-                <td>
-                  <div className="history-table-actions">
-                    <button
-                      type="button"
-                      className="btn btn-secondary btn-xs"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onSelect(job.id);
-                      }}
-                    >
-                      Consulter
-                    </button>
-                    <button
-                      type="button"
-                      className="btn btn-error btn-xs"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(job.id);
-                      }}
-                    >
-                      Supprimer
-                    </button>
                   </div>
                 </td>
               </tr>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1160,9 +1160,26 @@ pre {
 
 .history-table th,
 .history-table td {
-  padding: 0.85rem 1rem;
+  padding: 0.9rem 1.25rem;
   text-align: left;
   border-bottom: 1px solid var(--color-border);
+}
+
+.history-table th:first-child,
+.history-table td:first-child {
+  width: 45%;
+  padding-right: 1.5rem;
+}
+
+.history-table th:nth-child(2),
+.history-table td:nth-child(2) {
+  width: 160px;
+  white-space: nowrap;
+}
+
+.history-table th:nth-child(3),
+.history-table td:nth-child(3) {
+  width: 260px;
 }
 
 .history-table th {
@@ -1174,15 +1191,22 @@ pre {
 
 .history-table tbody tr {
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
 }
 
 .history-table tbody tr:hover {
-  background: rgba(0, 58, 99, 0.06);
+  background: rgba(0, 58, 99, 0.08);
+}
+
+.history-table tbody tr:focus-visible {
+  background: rgba(0, 58, 99, 0.12);
+  box-shadow: inset 0 0 0 2px rgba(0, 58, 99, 0.35);
 }
 
 .history-row--active {
-  background: rgba(0, 58, 99, 0.12);
+  background: rgba(0, 58, 99, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(0, 58, 99, 0.35);
 }
 
 .history-empty {
@@ -1360,12 +1384,6 @@ fieldset + fieldset {
 .toggle-field span {
   font-weight: 500;
   color: var(--color-text);
-}
-
-.history-table-actions {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: flex-end;
 }
 
 .history-table .text-muted {


### PR DESCRIPTION
## Summary
- remove the actions column from the job history table and keep progress/status inline
- update the job dashboard wiring after dropping the delete controls
- refresh the history table spacing and hover/focus styles for the new layout

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d6f0412f4483339409274d13cd5dcf