### PR TITLE
Rework job history layout and pipeline timeline

### DIFF
--- a/frontend/src/components/JobDashboard.jsx
+++ b/frontend/src/components/JobDashboard.jsx
@@ -35,7 +35,7 @@ export default function JobDashboard({ jobs, selectedJob, onSelectJob, onDeleteJ
   }, [selectedJob]);
 
   return (
-    <section className="grid gap-6 md:grid-cols-2">
+    <section className="history-stack">
       <div className="surface-card space-y-4">
         <div>
           <h2 className="section-title">Historique des traitements</h2>
@@ -43,8 +43,13 @@ export default function JobDashboard({ jobs, selectedJob, onSelectJob, onDeleteJ
         </div>
         <JobList jobs={jobs} selectedJob={selectedJob} onSelect={onSelectJob} onDelete={onDeleteJob} />
       </div>
-      <div className="surface-card">
-        <JobDetail job={selectedJob} logs={logs} isLoadingLogs={isLoadingLogs} />
+      <div className="surface-card history-detail-card">
+        <JobDetail
+          job={selectedJob}
+          logs={logs}
+          isLoadingLogs={isLoadingLogs}
+          onDeleteJob={onDeleteJob}
+        />
       </div>
     </section>
   );

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import StatusBadge from './StatusBadge.jsx';
 
 function formatTimestamp(seconds) {
@@ -29,24 +29,128 @@ function formatDuration(seconds) {
   return `${secs}s`;
 }
 
-export default function JobDetail({ job, logs, isLoadingLogs }) {
+function canPreviewMimeType(mimeType) {
+  if (!mimeType) {
+    return true;
+  }
+  const normalized = mimeType.toLowerCase();
+  return (
+    normalized.startsWith('text/') ||
+    normalized.includes('json') ||
+    normalized.includes('markdown') ||
+    normalized === 'application/xml'
+  );
+}
+
+export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   const [speakerData, setSpeakerData] = useState(null);
   const [isLoadingSpeakers, setIsLoadingSpeakers] = useState(false);
   const [speakersError, setSpeakersError] = useState(null);
+  const [selectedOutput, setSelectedOutput] = useState(null);
+  const [isLoadingOutput, setIsLoadingOutput] = useState(false);
+  const [outputError, setOutputError] = useState(null);
+  const [outputContent, setOutputContent] = useState('');
 
   const segmentsOutput = job?.outputs?.find((output) => output.filename === 'segments.json');
   const jobId = job?.id ?? null;
   const jobUpdatedAt = job?.updatedAt ?? null;
   const segmentsFilename = segmentsOutput?.filename ?? null;
   const segmentsKey = jobId && segmentsFilename ? `${jobId}:${segmentsFilename}:${jobUpdatedAt}` : null;
+  const outputs = useMemo(() => job?.outputs ?? [], [job?.outputs]);
+  const selectedOutputFilename = selectedOutput?.filename ?? null;
+  const selectedOutputMime = selectedOutput?.mimeType ?? null;
+  const canPreviewOutput = selectedOutput ? canPreviewMimeType(selectedOutputMime) : false;
+
+  useEffect(() => {
+    setSelectedOutput(null);
+    setIsLoadingOutput(false);
+    setOutputError(null);
+    setOutputContent('');
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!selectedOutputFilename) {
+      return;
+    }
+    const stillExists = outputs.some((output) => output.filename === selectedOutputFilename);
+    if (!stillExists) {
+      setSelectedOutput(null);
+      setIsLoadingOutput(false);
+      setOutputError(null);
+      setOutputContent('');
+    }
+  }, [outputs, selectedOutputFilename]);
+
+  useEffect(() => {
+    if (!jobId || !selectedOutput) {
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    let isMounted = true;
+    const { filename, mimeType } = selectedOutput;
+
+    if (!canPreviewMimeType(mimeType)) {
+      setOutputContent('');
+      setOutputError(null);
+      setIsLoadingOutput(false);
+      return () => {
+        isMounted = false;
+        controller.abort();
+      };
+    }
+
+    async function fetchOutput() {
+      setIsLoadingOutput(true);
+      setOutputError(null);
+      setOutputContent('');
+      try {
+        const response = await fetch(`/api/assets/${jobId}/${filename}`, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const rawText = await response.text();
+        let formatted = rawText;
+        if (mimeType?.toLowerCase().includes('json')) {
+          try {
+            formatted = JSON.stringify(JSON.parse(rawText), null, 2);
+          } catch (error) {
+            formatted = rawText;
+          }
+        }
+        if (isMounted) {
+          setOutputContent(formatted);
+        }
+      } catch (error) {
+        if (isMounted) {
+          const err = error instanceof Error ? error : new Error('Erreur inconnue');
+          if (err.name !== 'AbortError') {
+            setOutputError(err.message);
+          }
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoadingOutput(false);
+        }
+      }
+    }
+
+    fetchOutput();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [jobId, selectedOutput]);
 
   useEffect(() => {
     let isMounted = true;
-
-  if (!jobId || !segmentsFilename || !segmentsKey) {
-    setSpeakerData(null);
-    setSpeakersError(null);
-    setIsLoadingSpeakers(false);
+    if (!jobId || !segmentsFilename || !segmentsKey) {
+      setSpeakerData(null);
+      setSpeakersError(null);
+      setIsLoadingSpeakers(false);
       return () => {
         isMounted = false;
       };
@@ -103,12 +207,30 @@ export default function JobDetail({ job, logs, isLoadingLogs }) {
   return (
     <div className="history-detail">
       <header className="history-detail-header">
-        <div>
-          <h2 className="section-title">{job.filename}</h2>
-          <div className="text-base-content/70 text-sm">
-            Déclenché le {new Date(job.createdAt).toLocaleString()} • Dernière mise à jour{' '}
-            {new Date(job.updatedAt).toLocaleString()}
+        <div className="history-detail-heading">
+          <div>
+            <h2 className="section-title history-detail-title">{job.filename}</h2>
+            <div className="text-base-content/70 text-sm">
+              Déclenché le {new Date(job.createdAt).toLocaleString()} • Dernière mise à jour{' '}
+              {new Date(job.updatedAt).toLocaleString()}
+            </div>
           </div>
+          <button
+            type="button"
+            className="history-delete-btn btn btn-error btn-sm btn-icon"
+            onClick={() => {
+              if (
+                window.confirm(
+                  'Voulez-vous vraiment supprimer ce traitement ? Cette action est irréversible.'
+                )
+              ) {
+                onDeleteJob?.(job.id);
+              }
+            }}
+          >
+            <span className="sr-only">Supprimer ce traitement</span>
+            <span aria-hidden="true">🗑</span>
+          </button>
         </div>
         <div className="status-line">
           <div className="status-actions">
@@ -127,27 +249,66 @@ export default function JobDetail({ job, logs, isLoadingLogs }) {
         <h3 id="job-outputs" className="section-title">
           Exports disponibles
         </h3>
-        {job.outputs?.length ? (
+        {outputs.length ? (
           <div className="resource-list">
-            {job.outputs.map((output) => (
-              <a
-                key={output.filename}
-                className="resource-link"
-                href={`/api/assets/${job.id}/${output.filename}`}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <span>{output.label}</span>
-                <span className="text-base-content/70 text-sm">{output.mimeType}</span>
-              </a>
-            ))}
+            {outputs.map((output) => {
+              const isActive = selectedOutput?.filename === output.filename;
+              return (
+                <button
+                  key={output.filename}
+                  type="button"
+                  className={`resource-link${isActive ? ' is-active' : ''}`}
+                  onClick={() => {
+                    setSelectedOutput({
+                      filename: output.filename,
+                      label: output.label,
+                      mimeType: output.mimeType,
+                    });
+                  }}
+                >
+                  <span>{output.label}</span>
+                  <span className="text-base-content/70 text-sm">{output.mimeType}</span>
+                </button>
+              );
+            })}
           </div>
         ) : (
           <p className="text-base-content/70">Aucun export n'est encore disponible.</p>
         )}
+        {selectedOutput && (
+          <div className="resource-preview">
+            <div className="resource-preview__header">
+              <div>
+                <p className="resource-preview__title">{selectedOutput.label}</p>
+                <p className="resource-preview__meta text-sm">
+                  {selectedOutput.filename}
+                  {selectedOutput.mimeType ? ` • ${selectedOutput.mimeType}` : ''}
+                </p>
+              </div>
+              <a
+                className="btn btn-secondary btn-sm"
+                href={`/api/assets/${job.id}/${selectedOutput.filename}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Télécharger
+              </a>
+            </div>
+            {isLoadingOutput && <p className="text-base-content/70">Chargement de l'export…</p>}
+            {outputError && <p className="error-text">Impossible de charger l'export : {outputError}</p>}
+            {!isLoadingOutput && !outputError && !canPreviewOutput && (
+              <p className="text-base-content/70">
+                Ce format ne peut pas être prévisualisé. Utilisez le bouton de téléchargement pour le consulter.
+              </p>
+            )}
+            {!isLoadingOutput && !outputError && canPreviewOutput && (
+              <pre className="resource-preview__content">{outputContent}</pre>
+            )}
+          </div>
+        )}
       </section>
 
-      <section aria-labelledby="job-speakers" className="space-y-3">
+      <section aria-labelledby="job-speakers" className="space-y-3 history-speakers">
         <h3 id="job-speakers" className="section-title">
           Interventions par speaker
         </h3>
@@ -217,16 +378,26 @@ export default function JobDetail({ job, logs, isLoadingLogs }) {
         </h3>
         {isLoadingLogs && <p className="text-base-content/70">Chargement des logs…</p>}
         {logs.length ? (
-          <div className="log-list">
-            {logs.map((entry, index) => (
-              <div key={`${entry.timestamp}-${index}`} className="log-entry">
-                <div className="meta">
-                  {new Date(entry.timestamp).toLocaleTimeString()} • {entry.level?.toUpperCase()}
-                </div>
-                <div>{entry.message}</div>
-              </div>
-            ))}
-          </div>
+          <ol className="pipeline-timeline" aria-label="Chronologie du pipeline">
+            {logs.map((entry, index) => {
+              const level = typeof entry.level === 'string' ? entry.level.toLowerCase() : 'info';
+              const levelLabel = typeof entry.level === 'string' ? entry.level.toUpperCase() : 'INFO';
+              return (
+                <li
+                  key={`${entry.timestamp}-${index}`}
+                  className={`pipeline-timeline__item pipeline-timeline__item--${level}`}
+                >
+                  <div className="pipeline-timeline__marker" aria-hidden="true" />
+                  <div className="pipeline-timeline__content">
+                    <div className="pipeline-timeline__meta">
+                      {new Date(entry.timestamp).toLocaleTimeString()} • {levelLabel}
+                    </div>
+                    <div className="pipeline-timeline__message">{entry.message}</div>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
         ) : (
           !isLoadingLogs && <p className="logs-placeholder">Aucun événement pour le moment.</p>
         )}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -120,6 +120,18 @@ textarea {
   text-align: right;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .font-medium {
   font-weight: 600;
 }
@@ -506,6 +518,34 @@ textarea {
   white-space: pre-wrap;
 }
 
+.history-speakers {
+  font-size: 0.9rem;
+}
+
+.history-speakers .diarization-card {
+  padding: 0.85rem 1rem;
+}
+
+.history-speakers .diarization-card__title {
+  font-size: 0.95rem;
+}
+
+.history-speakers .diarization-card__metric {
+  font-size: 0.95rem;
+}
+
+.history-speakers .diarization-card__meta {
+  font-size: 0.8rem;
+}
+
+.history-speakers .diarization-segment {
+  padding: 0.85rem 1rem;
+}
+
+.history-speakers .diarization-segment__text {
+  font-size: 0.85rem;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -554,6 +594,14 @@ textarea {
 
 .btn-secondary:hover {
   background: rgba(0, 58, 99, 0.08);
+}
+
+.btn-icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border-radius: 999px;
+  font-size: 1rem;
 }
 
 .btn-ghost {
@@ -1058,6 +1106,7 @@ pre {
   font-weight: 600;
   text-decoration: none;
   transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
 }
 
 .resource-link:hover {
@@ -1065,6 +1114,17 @@ pre {
   border-color: rgba(0, 58, 99, 0.35);
   box-shadow: var(--shadow-soft);
   text-decoration: none;
+}
+
+.resource-link.is-active {
+  border-color: rgba(0, 58, 99, 0.45);
+  box-shadow: var(--shadow-soft);
+  background: rgba(0, 58, 99, 0.05);
+}
+
+.resource-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
 }
 
 .resource-link__icon {
@@ -1078,6 +1138,50 @@ pre {
   height: 1rem;
   color: var(--color-primary);
   opacity: 0.85;
+}
+
+.resource-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.resource-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.resource-preview__title {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.resource-preview__meta {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.resource-preview__content {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-app-bg);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  max-height: 24rem;
+  overflow: auto;
+  white-space: pre-wrap;
 }
 
 .audio-preview {
@@ -1192,25 +1296,43 @@ pre {
   padding: 1.5rem 1rem;
 }
 
+.history-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.history-detail-card {
+  padding: 1.75rem;
+}
+
 .history-detail-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 1.5rem;
   margin-bottom: 1.5rem;
 }
 
-.history-detail-actions {
+.history-detail-heading {
   display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.history-detail-title {
+  margin: 0 0 0.65rem;
+}
+
+.history-delete-btn {
+  flex-shrink: 0;
+  box-shadow: var(--shadow-soft);
 }
 
 .history-detail {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .history-subtitle {
@@ -1290,24 +1412,82 @@ legend {
   color: var(--color-error);
 }
 
-.log-list {
+.pipeline-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
-.log-entry {
+.pipeline-timeline__item {
+  position: relative;
+  display: flex;
+  gap: 1rem;
+  padding-left: 0.25rem;
+}
+
+.pipeline-timeline__item::after {
+  content: '';
+  position: absolute;
+  top: 1.25rem;
+  left: 0.55rem;
+  width: 2px;
+  height: calc(100% - 1.25rem);
+  background: var(--color-border);
+}
+
+.pipeline-timeline__item:last-child::after {
+  display: none;
+}
+
+.pipeline-timeline__marker {
+  position: relative;
+  flex: 0 0 1.1rem;
+  height: 1.1rem;
+  border-radius: 999px;
+  background: var(--color-border);
+  box-shadow: 0 0 0 6px rgba(15, 23, 42, 0.08);
+  margin-top: 0.15rem;
+}
+
+.pipeline-timeline__content {
+  flex: 1;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  padding: 0.75rem 1rem;
+  padding: 0.65rem 0.85rem;
   background: var(--color-surface);
   box-shadow: var(--shadow-soft);
 }
 
-.log-entry .meta {
-  font-size: 0.85rem;
+.pipeline-timeline__meta {
+  font-size: 0.8rem;
+  font-weight: 600;
   color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
   margin-bottom: 0.35rem;
+}
+
+.pipeline-timeline__message {
+  font-size: 0.95rem;
+}
+
+.pipeline-timeline__item--error .pipeline-timeline__marker {
+  background: var(--color-error);
+  box-shadow: 0 0 0 6px rgba(220, 38, 38, 0.12);
+}
+
+.pipeline-timeline__item--warning .pipeline-timeline__marker {
+  background: var(--color-secondary);
+  box-shadow: 0 0 0 6px rgba(246, 139, 30, 0.12);
+}
+
+.pipeline-timeline__item--success .pipeline-timeline__marker,
+.pipeline-timeline__item--completed .pipeline-timeline__marker {
+  background: var(--color-success);
+  box-shadow: 0 0 0 6px rgba(21, 128, 61, 0.12);
 }
 
 .template-grid {
@@ -1371,6 +1551,82 @@ fieldset + fieldset {
 .history-table .text-muted {
   color: var(--color-text-muted);
   font-size: 0.85rem;
+}
+
+.history-row-menu-header {
+  width: 3rem;
+  padding: 0.5rem 0.35rem;
+}
+
+.history-row-menu-cell {
+  width: 0;
+  text-align: right;
+  padding-left: 0.25rem;
+  padding-right: 0.35rem;
+}
+
+.history-row-menu {
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.history-row-menu-trigger {
+  color: var(--color-text-muted);
+}
+
+.history-row-menu-trigger:hover,
+.history-row-menu-trigger:focus-visible {
+  color: var(--color-primary);
+}
+
+.history-row-menu__content {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  min-width: 11rem;
+  padding: 0.35rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-floating);
+  z-index: 20;
+}
+
+.history-row-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.45rem 0.75rem;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+}
+
+.history-row-menu__item:hover,
+.history-row-menu__item:focus-visible {
+  background: rgba(0, 58, 99, 0.08);
+}
+
+.history-row-menu__item:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(0, 58, 99, 0.2);
+}
+
+.history-row-menu__item--danger {
+  color: var(--color-error);
+}
+
+.history-row-menu__item--danger:hover,
+.history-row-menu__item--danger:focus-visible {
+  background: rgba(220, 38, 38, 0.12);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- stack the job history table above its detail view while keeping the contextual actions menu tight against the right edge of each row
- move the delete shortcut next to the MP3 title in the detail header and retain inline export previews
- render the pipeline journal as a styled timeline that matches the updated interface

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d6f8f977c88333a7cc666ffa567866