### PR TITLE
Fix frontend fallback port

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,5 @@
 const origin = window.location.origin.replace(/\/$/, '');
-const fallback = origin.includes('5173') ? origin.replace(/:\d+$/, ':4001') : origin;
+const fallback = origin.includes('5173') ? origin.replace(/:\d+$/, ':4000') : origin;
 const API_BASE = import.meta.env.VITE_BACKEND_URL || fallback;
 
 async function request(path, options = {}) {


### PR DESCRIPTION
## Summary
- update the frontend API client fallback to point to port 4000 when the app runs from localhost:5173

## Testing
- npm run build
- npm run dev (backend) and manually fetched http://localhost:4000/api/config

------
https://chatgpt.com/codex/tasks/task_e_68d7191d14608333ae2fff001bb09332