### PR TITLE
fix: align frontend proxy fallback port with backend default

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig(({ mode }) => {
     env.VITE_BACKEND_URL
     || env.BACKEND_URL
     || (env.BACKEND_PORT ? `http://localhost:${env.BACKEND_PORT}` : null)
-    || 'http://localhost:4001';
+    || 'http://localhost:4000';
 
   return {
     plugins: [react()],


### PR DESCRIPTION
## Summary
- update the Vite dev server proxy fallback to point at port 4000 so it matches the backend default

## Testing
- npm run dev (backend)
- npm run dev (frontend)
- curl -i http://localhost:5173/api/config

------
https://chatgpt.com/codex/tasks/task_e_68d79e3f7f08833391fa3c1bea037a67