### PR TITLE
Use shared API base for asset URLs

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,6 +1,6 @@
 const origin = window.location.origin.replace(/\/$/, '');
 const fallback = origin.includes('5173') ? origin.replace(/:\d+$/, ':4000') : origin;
-const API_BASE = import.meta.env.VITE_BACKEND_URL || fallback;
+export const API_BASE = import.meta.env.VITE_BACKEND_URL || fallback;
 
 async function request(path, options = {}) {
   const response = await fetch(`${API_BASE}${path}`, {

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { API_BASE } from '../api/client.js';
 import StatusBadge from './StatusBadge.jsx';
 
 function formatTimestamp(seconds) {
@@ -105,7 +106,7 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
       setOutputError(null);
       setOutputContent('');
       try {
-        const response = await fetch(`/api/assets/${jobId}/${filename}`, {
+        const response = await fetch(`${API_BASE}/api/assets/${jobId}/${filename}`, {
           signal: controller.signal,
         });
         if (!response.ok) {
@@ -163,7 +164,7 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
 
     async function fetchSegments() {
       try {
-        const response = await fetch(`/api/assets/${jobId}/${segmentsFilename}`, {
+        const response = await fetch(`${API_BASE}/api/assets/${jobId}/${segmentsFilename}`, {
           signal: controller.signal,
         });
         if (!response.ok) {
@@ -287,7 +288,7 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
               </div>
               <a
                 className="btn btn-secondary btn-sm"
-                href={`/api/assets/${job.id}/${selectedOutput.filename}`}
+                href={`${API_BASE}/api/assets/${job.id}/${selectedOutput.filename}`}
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
## Summary
- export the computed API base from the API client for reuse
- build asset fetches and download links in the job detail view from the shared base so they work with or without the dev proxy

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d7a10cb33c8333b9721c987d35bf21