### PR TITLE
Add pipeline step metadata and accordion log display

### DIFF
--- a/backend/src/persistence/job-store.ts
+++ b/backend/src/persistence/job-store.ts
@@ -109,9 +109,19 @@ class FileJobStore implements JobStore {
     return updated;
   }
 
-  async appendLog(id: string, message: string, level: LogLevel = 'info'): Promise<JobLogEntry> {
+  async appendLog(
+    id: string,
+    message: string,
+    level: LogLevel = 'info',
+    pipelineStep: string | null = null,
+  ): Promise<JobLogEntry> {
     const entries = this.logs.get(id) ?? [];
-    const entry: JobLogEntry = { timestamp: new Date().toISOString(), level, message };
+    const entry: JobLogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      pipelineStep,
+    };
     entries.push(entry);
     this.logs.set(id, entries);
     await this.persist();

--- a/backend/src/pipeline/engine.ts
+++ b/backend/src/pipeline/engine.ts
@@ -111,7 +111,7 @@ export class PipelineEngine {
         this.logger.info({ jobId: nextId }, 'Pipeline job cancelled before completion');
         if (jobStillExists) {
           await this.jobStore.update(nextId, { status: 'failed' });
-          await this.jobStore.appendLog(nextId, 'Pipeline annulé par l’utilisateur', 'warn');
+          await this.jobStore.appendLog(nextId, 'Pipeline annulé par l’utilisateur', 'warn', 'pipeline');
         } else {
           this.logger.debug({ jobId: nextId }, 'Skipping cancellation persistence because job no longer exists');
         }
@@ -122,7 +122,7 @@ export class PipelineEngine {
         );
         if (jobStillExists) {
           await this.jobStore.update(nextId, { status: 'failed' });
-          await this.jobStore.appendLog(nextId, `Pipeline failed: ${error.message}`, 'error');
+          await this.jobStore.appendLog(nextId, `Pipeline failed: ${error.message}`, 'error', 'pipeline');
         } else {
           this.logger.debug({ jobId: nextId }, 'Skipping failure persistence because job no longer exists');
         }
@@ -146,7 +146,7 @@ export class PipelineEngine {
     }
 
     await this.jobStore.update(jobId, { status: 'processing', progress: 0 });
-    await this.jobStore.appendLog(jobId, 'Pipeline démarré');
+    await this.jobStore.appendLog(jobId, 'Pipeline démarré', 'info', 'pipeline');
     this.logger.info({ jobId, filename: job.filename, templateId: job.templateId }, 'Pipeline job started');
 
     const config = await this.configStore.read();
@@ -194,7 +194,7 @@ export class PipelineEngine {
     }
 
     await this.jobStore.update(jobId, { status: 'completed' });
-    await this.jobStore.appendLog(jobId, 'Pipeline terminé avec succès');
+    await this.jobStore.appendLog(jobId, 'Pipeline terminé avec succès', 'info', 'pipeline');
     this.logger.info({ jobId }, 'Pipeline job completed successfully');
   }
 }

--- a/backend/src/pipeline/steps/diarize-step.ts
+++ b/backend/src/pipeline/steps/diarize-step.ts
@@ -39,7 +39,7 @@ export async function diarizeStep(context: PipelineContext): Promise<void> {
 
   if (!config.pipeline.enableDiarization) {
     logger.info({ jobId: job.id }, 'Diarize step skipped because diarization disabled');
-    await jobStore.appendLog(job.id, 'Diarisation désactivée, étape ignorée');
+    await jobStore.appendLog(job.id, 'Diarisation désactivée, étape ignorée', 'info', 'diarize');
     context.data.diarization = [];
     return;
   }
@@ -48,12 +48,12 @@ export async function diarizeStep(context: PipelineContext): Promise<void> {
   if (!inputPath) {
     const message = 'Chemin audio introuvable, diarisation ignorée';
     logger.warn({ jobId: job.id }, 'Diarize step skipped due to missing audio path');
-    await jobStore.appendLog(job.id, message, 'warn');
+    await jobStore.appendLog(job.id, message, 'warn', 'diarize');
     context.data.diarization = [];
     return;
   }
 
-  await jobStore.appendLog(job.id, 'Diarisation des locuteurs');
+  await jobStore.appendLog(job.id, 'Diarisation des locuteurs', 'info', 'diarize');
 
   try {
     const diarizationDir = path.join(environment.jobsDir, job.id, 'diarization');
@@ -69,10 +69,10 @@ export async function diarizeStep(context: PipelineContext): Promise<void> {
       { jobId: job.id, segmentCount: segments.length },
       'Diarize step completed',
     );
-    await jobStore.appendLog(job.id, 'Diarisation générée');
+    await jobStore.appendLog(job.id, 'Diarisation générée', 'info', 'diarize');
   } catch (error) {
     logger.error({ jobId: job.id, error }, 'Diarize step failed');
-    await jobStore.appendLog(job.id, "Diarisation échouée, étape ignorée", 'warn');
+    await jobStore.appendLog(job.id, "Diarisation échouée, étape ignorée", 'warn', 'diarize');
     context.data.diarization = context.data.diarization ?? [];
   }
 }

--- a/backend/src/pipeline/steps/export-step.ts
+++ b/backend/src/pipeline/steps/export-step.ts
@@ -12,7 +12,7 @@ export async function exportStep(context: PipelineContext): Promise<void> {
   const jobDir = path.join(environment.jobsDir, job.id);
   const outputs: JobOutput[] = [];
 
-  await jobStore.appendLog(job.id, 'Export des livrables');
+  await jobStore.appendLog(job.id, 'Export des livrables', 'info', 'export');
   logger.info({ jobId: job.id, jobDir }, 'Export step started');
 
   const transcription = context.data.transcription?.text ?? '';
@@ -101,7 +101,7 @@ export async function exportStep(context: PipelineContext): Promise<void> {
   context.data.outputs = outputs;
   logger.info({ jobId: job.id, outputCount: outputs.length }, 'Export step completed');
 
-  await jobStore.appendLog(job.id, 'Exports finalisés');
+  await jobStore.appendLog(job.id, 'Exports finalisés', 'info', 'export');
 }
 
 function buildVtt(

--- a/backend/src/pipeline/steps/ingest-step.ts
+++ b/backend/src/pipeline/steps/ingest-step.ts
@@ -7,7 +7,7 @@ export async function ingestStep(context: PipelineContext): Promise<void> {
   const sourcePath = path.join(jobDir, job.filename);
   const preparedPath = path.join(jobDir, 'prepared.wav');
 
-  await jobStore.appendLog(job.id, 'Prétraitement audio (FFmpeg)');
+  await jobStore.appendLog(job.id, 'Prétraitement audio (FFmpeg)', 'info', 'ingest');
   logger.info({ jobId: job.id, sourcePath, preparedPath }, 'Ingest step started');
 
   // L'usage de FFmpeg permet de normaliser les volumes avant la transcription pour de meilleures performances.
@@ -15,12 +15,12 @@ export async function ingestStep(context: PipelineContext): Promise<void> {
     await services.ffmpeg.normalizeAudio({ input: sourcePath, output: preparedPath });
     context.data.preparedPath = preparedPath;
     logger.info({ jobId: job.id, preparedPath }, 'Audio normalisation completed');
-    await jobStore.appendLog(job.id, 'Fichier audio normalisé');
+    await jobStore.appendLog(job.id, 'Fichier audio normalisé', 'info', 'ingest');
   } catch (unknownError) {
     // En cas d'échec, on tombe en mode dégradé afin de ne pas bloquer le pipeline complet.
     const error = unknownError instanceof Error ? unknownError : new Error('FFmpeg normalisation failed');
     logger.warn({ jobId: job.id, sourcePath, preparedPath, message: error.message }, 'Audio normalisation failed');
-    await jobStore.appendLog(job.id, `Normalisation FFmpeg échouée : ${error.message}`, 'warn');
+    await jobStore.appendLog(job.id, `Normalisation FFmpeg échouée : ${error.message}`, 'warn', 'ingest');
     context.data.preparedPath = sourcePath;
     logger.info({ jobId: job.id, fallbackPath: sourcePath }, 'Fallback to original audio for transcription');
   }

--- a/backend/src/pipeline/steps/summarise-step.ts
+++ b/backend/src/pipeline/steps/summarise-step.ts
@@ -6,7 +6,7 @@ export async function summariseStep(context: PipelineContext): Promise<void> {
 
   if (!config.pipeline.enableSummaries) {
     // Permet de court-circuiter l'appel LLM lorsqu'il est désactivé dans la configuration.
-    await jobStore.appendLog(job.id, 'Synthèse LLM désactivée, étape ignorée');
+    await jobStore.appendLog(job.id, 'Synthèse LLM désactivée, étape ignorée', 'info', 'summarise');
     logger.info({ jobId: job.id }, 'Summarise step skipped because summaries disabled');
     context.data.summary = null;
     return;
@@ -14,13 +14,13 @@ export async function summariseStep(context: PipelineContext): Promise<void> {
 
   const transcription = context.data.transcription;
   if (!transcription) {
-    await jobStore.appendLog(job.id, 'Transcription manquante, résumé ignoré', 'warn');
+    await jobStore.appendLog(job.id, 'Transcription manquante, résumé ignoré', 'warn', 'summarise');
     logger.warn({ jobId: job.id }, 'Summarise step skipped due to missing transcription');
     context.data.summary = null;
     return;
   }
 
-  await jobStore.appendLog(job.id, 'Génération du résumé (OpenAI)');
+  await jobStore.appendLog(job.id, 'Génération du résumé (OpenAI)', 'info', 'summarise');
   const { provider, model, temperature, maxOutputTokens } = config.llm;
 
   const speakerTimeline = buildSpeakerTimeline(context.data.transcription?.segments);
@@ -52,7 +52,7 @@ export async function summariseStep(context: PipelineContext): Promise<void> {
         ? "Résumé ignoré : clé API OpenAI manquante"
         : 'Résumé non généré par le service OpenAI';
 
-    await jobStore.appendLog(job.id, skippedMessage, 'warn');
+    await jobStore.appendLog(job.id, skippedMessage, 'warn', 'summarise');
     logger.warn({ jobId: job.id, reason: summary?.reason ?? 'unknown' }, 'Summarise step did not produce content');
     context.data.summary = null;
     return;
@@ -61,5 +61,5 @@ export async function summariseStep(context: PipelineContext): Promise<void> {
   context.data.summary = { markdown };
   logger.info({ jobId: job.id, markdownLength: markdown.length }, 'Summarise step completed');
 
-  await jobStore.appendLog(job.id, 'Résumé généré');
+  await jobStore.appendLog(job.id, 'Résumé généré', 'info', 'summarise');
 }

--- a/backend/src/pipeline/steps/transcribe-step.ts
+++ b/backend/src/pipeline/steps/transcribe-step.ts
@@ -20,7 +20,7 @@ export async function transcribeStep(context: PipelineContext): Promise<void> {
     );
   }
 
-  await jobStore.appendLog(job.id, 'Transcription locale (Whisper)');
+  await jobStore.appendLog(job.id, 'Transcription locale (Whisper)', 'info', 'transcribe');
   logger.info(
     {
       jobId: job.id,
@@ -49,5 +49,5 @@ export async function transcribeStep(context: PipelineContext): Promise<void> {
     'Transcribe step completed',
   );
 
-  await jobStore.appendLog(job.id, 'Transcription générée');
+  await jobStore.appendLog(job.id, 'Transcription générée', 'info', 'transcribe');
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -43,6 +43,7 @@ export interface JobLogEntry {
   timestamp: string;
   level: LogLevel;
   message: string;
+  pipelineStep?: string | null;
 }
 
 export interface JobsFilePayload {
@@ -207,7 +208,7 @@ export interface JobStore {
   get(id: string): Promise<Job | null>;
   create(args: { filename: string; tempPath: string; templateId: string | null; participants: string[] }): Promise<Job>;
   update(id: string, updates: Partial<Job>): Promise<Job>;
-  appendLog(id: string, message: string, level?: LogLevel): Promise<JobLogEntry>;
+  appendLog(id: string, message: string, level?: LogLevel, pipelineStep?: string | null): Promise<JobLogEntry>;
   getLogs(id: string): Promise<JobLogEntry[]>;
   addOutput(id: string, output: JobOutput): Promise<Job>;
   remove(id: string): Promise<void>;

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { API_BASE } from '../api/client.js';
 import StatusBadge from './StatusBadge.jsx';
 
@@ -43,6 +43,55 @@ function canPreviewMimeType(mimeType) {
   );
 }
 
+const PIPELINE_STEPS = [
+  {
+    key: 'pipeline',
+    label: 'Orchestration',
+    description: 'États globaux et transitions du pipeline',
+  },
+  {
+    key: 'ingest',
+    label: 'Prétraitement audio',
+    description: 'Normalisation et préparation des supports audio',
+  },
+  {
+    key: 'transcribe',
+    label: 'Transcription',
+    description: 'Conversion audio → texte',
+  },
+  {
+    key: 'diarize',
+    label: 'Diarisation',
+    description: 'Identification des locuteurs',
+  },
+  {
+    key: 'summarise',
+    label: 'Synthèse',
+    description: 'Génération des résumés automatiques',
+  },
+  {
+    key: 'export',
+    label: 'Exports',
+    description: 'Production des livrables finaux',
+  },
+];
+
+const PIPELINE_FALLBACK_STEP = {
+  key: 'misc',
+  label: 'Divers',
+  description: 'Événements généraux ou hors pipeline',
+};
+
+const LOG_LEVEL_LABELS = {
+  debug: 'DEBUG',
+  info: 'INFO',
+  warn: 'WARN',
+  warning: 'WARN',
+  error: 'ERROR',
+};
+
+const KNOWN_LOG_LEVELS = new Set(['info', 'warn', 'error', 'debug']);
+
 export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   const [speakerData, setSpeakerData] = useState(null);
   const [isLoadingSpeakers, setIsLoadingSpeakers] = useState(false);
@@ -51,6 +100,10 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   const [isLoadingOutput, setIsLoadingOutput] = useState(false);
   const [outputError, setOutputError] = useState(null);
   const [outputContent, setOutputContent] = useState('');
+  const [expandedPipelineStep, setExpandedPipelineStep] = useState(
+    PIPELINE_STEPS[0]?.key ?? PIPELINE_FALLBACK_STEP.key,
+  );
+  const hasInteractedWithPipeline = useRef(false);
 
   const segmentsOutput = job?.outputs?.find((output) => output.filename === 'segments.json');
   const jobId = job?.id ?? null;
@@ -61,6 +114,43 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   const selectedOutputFilename = selectedOutput?.filename ?? null;
   const selectedOutputMime = selectedOutput?.mimeType ?? null;
   const canPreviewOutput = selectedOutput ? canPreviewMimeType(selectedOutputMime) : false;
+  const pipelineSections = useMemo(() => {
+    const safeLogs = Array.isArray(logs) ? logs : [];
+    const groups = new Map();
+    const knownKeys = new Set([...PIPELINE_STEPS.map((step) => step.key), PIPELINE_FALLBACK_STEP.key]);
+
+    for (const entry of safeLogs) {
+      const rawKey =
+        typeof entry.pipelineStep === 'string' ? entry.pipelineStep.trim().toLowerCase() : '';
+      const key = rawKey && knownKeys.has(rawKey) ? rawKey : PIPELINE_FALLBACK_STEP.key;
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key)?.push(entry);
+    }
+
+    const sortEntries = (entries) =>
+      [...entries].sort((a, b) => {
+        const parsedA = Date.parse(a?.timestamp ?? '');
+        const parsedB = Date.parse(b?.timestamp ?? '');
+        const timeA = Number.isFinite(parsedA) ? parsedA : 0;
+        const timeB = Number.isFinite(parsedB) ? parsedB : 0;
+        return timeA - timeB;
+      });
+
+    const sections = PIPELINE_STEPS.map((step) => ({
+      ...step,
+      entries: sortEntries(groups.get(step.key) ?? []),
+    }));
+
+    sections.push({
+      ...PIPELINE_FALLBACK_STEP,
+      entries: sortEntries(groups.get(PIPELINE_FALLBACK_STEP.key) ?? []),
+    });
+
+    return sections;
+  }, [logs]);
+  const hasLogs = pipelineSections.some((section) => section.entries.length > 0);
 
   useEffect(() => {
     setSelectedOutput(null);
@@ -81,6 +171,31 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
       setOutputContent('');
     }
   }, [outputs, selectedOutputFilename]);
+
+  useEffect(() => {
+    if (!pipelineSections.length) {
+      return;
+    }
+
+    const currentSection = pipelineSections.find((section) => section.key === expandedPipelineStep);
+
+    if (!currentSection) {
+      const fallbackKey = pipelineSections[0]?.key ?? PIPELINE_FALLBACK_STEP.key;
+      setExpandedPipelineStep(fallbackKey);
+      return;
+    }
+
+    if (hasInteractedWithPipeline.current) {
+      return;
+    }
+
+    if (currentSection.entries.length === 0) {
+      const firstWithLogs = pipelineSections.find((section) => section.entries.length > 0);
+      if (firstWithLogs && firstWithLogs.key !== expandedPipelineStep) {
+        setExpandedPipelineStep(firstWithLogs.key);
+      }
+    }
+  }, [pipelineSections, expandedPipelineStep]);
 
   useEffect(() => {
     if (!jobId || !selectedOutput) {
@@ -199,6 +314,11 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   if (!job) {
     return <p className="history-empty">Sélectionnez un traitement pour afficher les détails.</p>;
   }
+
+  const togglePipelineSection = (key) => {
+    hasInteractedWithPipeline.current = true;
+    setExpandedPipelineStep((current) => (current === key ? current : key));
+  };
 
   const hasSegmentsOutput = job.outputs?.some((output) => output.filename === 'segments.json');
   const progressValue = Math.round(job.progress ?? 0);
@@ -378,30 +498,91 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
           Journal du pipeline
         </h3>
         {isLoadingLogs && <p className="text-base-content/70">Chargement des logs…</p>}
-        {logs.length ? (
-          <ol className="pipeline-timeline" aria-label="Chronologie du pipeline">
-            {logs.map((entry, index) => {
-              const level = typeof entry.level === 'string' ? entry.level.toLowerCase() : 'info';
-              const levelLabel = typeof entry.level === 'string' ? entry.level.toUpperCase() : 'INFO';
-              return (
-                <li
-                  key={`${entry.timestamp}-${index}`}
-                  className={`pipeline-timeline__item pipeline-timeline__item--${level}`}
-                >
-                  <div className="pipeline-timeline__marker" aria-hidden="true" />
-                  <div className="pipeline-timeline__content">
-                    <div className="pipeline-timeline__meta">
-                      {new Date(entry.timestamp).toLocaleTimeString()} • {levelLabel}
-                    </div>
-                    <div className="pipeline-timeline__message">{entry.message}</div>
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
-        ) : (
-          !isLoadingLogs && <p className="logs-placeholder">Aucun événement pour le moment.</p>
+        {!isLoadingLogs && !hasLogs && (
+          <p className="logs-placeholder">Aucun événement pour le moment.</p>
         )}
+        <dl className="pipeline-accordion" aria-label="Journal du pipeline">
+          {pipelineSections.map((section) => {
+            const isOpen = expandedPipelineStep === section.key;
+            const entryCount = section.entries.length;
+            const eventLabel =
+              entryCount === 0
+                ? '0 événement'
+                : entryCount === 1
+                ? '1 événement'
+                : `${entryCount} événements`;
+            const panelId = `pipeline-panel-${section.key}`;
+            const buttonId = `pipeline-trigger-${section.key}`;
+
+            return (
+              <div
+                key={section.key}
+                className={`pipeline-accordion__item${isOpen ? ' pipeline-accordion__item--open' : ''}`}
+              >
+                <dt className="pipeline-accordion__summary">
+                  <button
+                    type="button"
+                    className="pipeline-accordion__button"
+                    aria-expanded={isOpen}
+                    aria-controls={panelId}
+                    id={buttonId}
+                    onClick={() => togglePipelineSection(section.key)}
+                  >
+                    <span className="pipeline-accordion__summary-text">
+                      <span className="pipeline-accordion__title">{section.label}</span>
+                      {section.description ? (
+                        <span className="pipeline-accordion__description">{section.description}</span>
+                      ) : null}
+                    </span>
+                    <span className="pipeline-accordion__meta">{eventLabel}</span>
+                    <span className="pipeline-accordion__chevron" aria-hidden="true" />
+                  </button>
+                </dt>
+                <dd
+                  id={panelId}
+                  className="pipeline-accordion__panel"
+                  aria-labelledby={buttonId}
+                  role="region"
+                  hidden={!isOpen}
+                >
+                  {entryCount ? (
+                    <ol className="pipeline-accordion__logs">
+                      {section.entries.map((entry, index) => {
+                        const normalisedLevel =
+                          typeof entry.level === 'string' ? entry.level.toLowerCase() : 'info';
+                        const levelKey = normalisedLevel === 'warning' ? 'warn' : normalisedLevel;
+                        const safeLevelKey = KNOWN_LOG_LEVELS.has(levelKey) ? levelKey : 'info';
+                        const levelLabel =
+                          LOG_LEVEL_LABELS[levelKey] ?? LOG_LEVEL_LABELS[safeLevelKey] ?? safeLevelKey.toUpperCase();
+                        const timestampLabel = entry.timestamp
+                          ? new Date(entry.timestamp).toLocaleTimeString()
+                          : '—';
+                        return (
+                          <li
+                            key={`${entry.timestamp}-${index}`}
+                            className={`pipeline-accordion__log pipeline-accordion__log--${safeLevelKey}`}
+                          >
+                            <div className="pipeline-accordion__log-header">
+                              <span className="pipeline-accordion__timestamp">{timestampLabel}</span>
+                              <span className={`pipeline-accordion__level pipeline-accordion__level--${safeLevelKey}`}>
+                                {levelLabel}
+                              </span>
+                            </div>
+                            <p className="pipeline-accordion__message">{entry.message}</p>
+                          </li>
+                        );
+                      })}
+                    </ol>
+                  ) : (
+                    <p className="pipeline-accordion__empty">
+                      Aucun événement enregistré pour cette étape.
+                    </p>
+                  )}
+                </dd>
+              </div>
+            );
+          })}
+        </dl>
       </section>
     </div>
   );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1412,6 +1412,206 @@ legend {
   color: var(--color-error);
 }
 
+.pipeline-accordion {
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.pipeline-accordion__item + .pipeline-accordion__item {
+  border-top: 1px solid var(--color-border);
+}
+
+.pipeline-accordion__item--open .pipeline-accordion__button {
+  background: var(--color-surface-soft);
+}
+
+.pipeline-accordion__item--open .pipeline-accordion__chevron {
+  transform: rotate(225deg);
+  border-color: var(--color-primary);
+}
+
+.pipeline-accordion__summary {
+  margin: 0;
+}
+
+.pipeline-accordion__button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.pipeline-accordion__button:hover {
+  background: rgba(243, 244, 246, 0.6);
+}
+
+.pipeline-accordion__button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.pipeline-accordion__summary-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.pipeline-accordion__title {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--color-text);
+}
+
+.pipeline-accordion__description {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.pipeline-accordion__meta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.pipeline-accordion__chevron {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-right: 2px solid var(--color-text-muted);
+  border-bottom: 2px solid var(--color-text-muted);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.pipeline-accordion__panel {
+  margin: 0;
+  padding: 0 1.5rem 1.5rem;
+  background: transparent;
+}
+
+.pipeline-accordion__panel[hidden] {
+  display: none;
+}
+
+.pipeline-accordion__logs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.pipeline-accordion__log {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.85rem 1rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+}
+
+.pipeline-accordion__log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.4rem;
+}
+
+.pipeline-accordion__timestamp {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.pipeline-accordion__level {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: var(--color-border);
+  color: var(--color-text);
+}
+
+.pipeline-accordion__level--info {
+  background: rgba(0, 58, 99, 0.12);
+  color: var(--color-primary);
+}
+
+.pipeline-accordion__level--warn {
+  background: rgba(246, 139, 30, 0.16);
+  color: var(--color-secondary);
+}
+
+.pipeline-accordion__level--error {
+  background: rgba(220, 38, 38, 0.16);
+  color: var(--color-error);
+}
+
+.pipeline-accordion__level--debug {
+  background: rgba(99, 102, 241, 0.16);
+  color: #3730a3;
+}
+
+.pipeline-accordion__log--warn {
+  border-color: rgba(246, 139, 30, 0.4);
+  background: rgba(246, 139, 30, 0.08);
+}
+
+.pipeline-accordion__log--error {
+  border-color: rgba(220, 38, 38, 0.45);
+  background: rgba(220, 38, 38, 0.08);
+}
+
+.pipeline-accordion__log--debug {
+  border-color: rgba(99, 102, 241, 0.35);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.pipeline-accordion__message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.pipeline-accordion__empty {
+  margin: 0;
+  padding: 0.75rem 0;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .pipeline-accordion__button {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .pipeline-accordion__meta {
+    order: 3;
+    width: 100%;
+  }
+
+  .pipeline-accordion__chevron {
+    margin-left: auto;
+  }
+}
+
 .pipeline-timeline {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- attach pipeline step metadata to job log entries and persist it from each pipeline phase
- replace the job log timeline with a grouped accordion view and fallback "Divers" section in the job detail page
- add accordion styling that matches the app radius and color guidelines

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68d7a4f1acc483338aacf8e4a8666fd6