### PR TITLE
feat: add console log view with copy support

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1490,6 +1490,101 @@ legend {
   box-shadow: 0 0 0 6px rgba(21, 128, 61, 0.12);
 }
 
+.pipeline-log-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn-group {
+  display: inline-flex;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+}
+
+.btn-group > .btn {
+  border-radius: 0;
+  border: none;
+  min-width: 6.5rem;
+}
+
+.pipeline-console {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 24rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  overflow-y: auto;
+}
+
+.console-line {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  background: var(--color-surface-soft);
+}
+
+.console-line__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.console-line__message {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text);
+}
+
+.console-line__level {
+  padding: 0.15rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.console-line--info .console-line__level {
+  color: var(--color-primary);
+  background: rgba(0, 58, 99, 0.12);
+}
+
+.console-line--warning .console-line__level {
+  color: var(--color-secondary);
+  background: rgba(246, 139, 30, 0.18);
+}
+
+.console-line--error .console-line__level {
+  color: var(--color-error);
+  background: rgba(220, 38, 38, 0.18);
+}
+
+.console-line--success .console-line__level,
+.console-line--completed .console-line__level {
+  color: var(--color-success);
+  background: rgba(21, 128, 61, 0.18);
+}
+
+.console-line--debug .console-line__level {
+  color: var(--color-text-muted);
+  background: rgba(15, 23, 42, 0.12);
+}
+
 .template-grid {
   display: grid;
   gap: 1.25rem;


### PR DESCRIPTION
## Summary
- add an optional console view for pipeline logs with aria-live updates for new events
- provide clipboard export for the full log stream and toggle controls between views
- style the new console layout and log levels using the existing design palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7a81a13a083339b2bcd48575e8883