### PR TITLE
feat: restyle pipeline log timeline as stepper

### DIFF
--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -227,21 +227,23 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
         </h3>
         {isLoadingLogs && <p className="text-base-content/70">Chargement des logs…</p>}
         {logs.length ? (
-          <ol className="pipeline-timeline" aria-label="Chronologie du pipeline">
+          <ol className="pipeline-stepper" aria-label="Chronologie du pipeline">
             {logs.map((entry, index) => {
               const level = typeof entry.level === 'string' ? entry.level.toLowerCase() : 'info';
               const levelLabel = typeof entry.level === 'string' ? entry.level.toUpperCase() : 'INFO';
               return (
                 <li
                   key={`${entry.timestamp}-${index}`}
-                  className={`pipeline-timeline__item pipeline-timeline__item--${level}`}
+                  className={`pipeline-stepper__item pipeline-stepper__item--${level}`}
                 >
-                  <div className="pipeline-timeline__marker" aria-hidden="true" />
-                  <div className="pipeline-timeline__content">
-                    <div className="pipeline-timeline__meta">
+                  <span className="pipeline-stepper__index" aria-hidden="true">
+                    {index + 1}
+                  </span>
+                  <div className="pipeline-stepper__body">
+                    <div className="pipeline-stepper__meta">
                       {new Date(entry.timestamp).toLocaleTimeString()} • {levelLabel}
                     </div>
-                    <div className="pipeline-timeline__message">{entry.message}</div>
+                    <div className="pipeline-stepper__message">{entry.message}</div>
                   </div>
                 </li>
               );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1412,56 +1412,75 @@ legend {
   color: var(--color-error);
 }
 
-.pipeline-timeline {
+.pipeline-stepper {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
-.pipeline-timeline__item {
+.pipeline-stepper__item,
+.pipeline-stepper__item--info {
+  --step-color: var(--color-primary);
   position: relative;
-  display: flex;
-  gap: 1rem;
-  padding-left: 0.25rem;
+  display: grid;
+  grid-template-columns: 2.5rem 1fr;
+  column-gap: 1rem;
+  align-items: flex-start;
 }
 
-.pipeline-timeline__item::after {
+.pipeline-stepper__item::before {
   content: '';
   position: absolute;
-  top: 1.25rem;
-  left: 0.55rem;
+  top: 2.5rem;
+  left: 1.25rem;
   width: 2px;
-  height: calc(100% - 1.25rem);
-  background: var(--color-border);
+  height: calc(100% - 2.5rem);
+  background: var(--step-color);
+  background: color-mix(in srgb, var(--step-color) 45%, transparent);
+  opacity: 0.6;
 }
 
-.pipeline-timeline__item:last-child::after {
+.pipeline-stepper__item:last-child::before {
   display: none;
 }
 
-.pipeline-timeline__marker {
+.pipeline-stepper__index {
   position: relative;
-  flex: 0 0 1.1rem;
-  height: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 999px;
-  background: var(--color-border);
-  box-shadow: 0 0 0 6px rgba(15, 23, 42, 0.08);
-  margin-top: 0.15rem;
+  font-weight: 700;
+  font-size: 1rem;
+  background: var(--step-color);
+  background: color-mix(in srgb, var(--step-color) 18%, var(--color-surface));
+  border: 2px solid var(--step-color);
+  color: var(--color-surface);
+  box-shadow: 0 0 0 4px rgba(15, 23, 42, 0.08);
 }
 
-.pipeline-timeline__content {
-  flex: 1;
+@supports (background: color-mix(in srgb, white 0%, black 0%)) {
+  .pipeline-stepper__index {
+    color: var(--step-color);
+  }
+}
+
+.pipeline-stepper__body {
   border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--step-color);
+  border: 1px solid color-mix(in srgb, var(--step-color) 35%, var(--color-border));
+  padding: 0.75rem 1rem;
   background: var(--color-surface);
+  background: color-mix(in srgb, var(--step-color) 12%, var(--color-surface));
   box-shadow: var(--shadow-soft);
 }
 
-.pipeline-timeline__meta {
+.pipeline-stepper__meta {
   font-size: 0.8rem;
   font-weight: 600;
   color: var(--color-text-muted);
@@ -1470,24 +1489,21 @@ legend {
   margin-bottom: 0.35rem;
 }
 
-.pipeline-timeline__message {
+.pipeline-stepper__message {
   font-size: 0.95rem;
 }
 
-.pipeline-timeline__item--error .pipeline-timeline__marker {
-  background: var(--color-error);
-  box-shadow: 0 0 0 6px rgba(220, 38, 38, 0.12);
+.pipeline-stepper__item--error {
+  --step-color: var(--color-error);
 }
 
-.pipeline-timeline__item--warning .pipeline-timeline__marker {
-  background: var(--color-secondary);
-  box-shadow: 0 0 0 6px rgba(246, 139, 30, 0.12);
+.pipeline-stepper__item--warning {
+  --step-color: var(--color-secondary);
 }
 
-.pipeline-timeline__item--success .pipeline-timeline__marker,
-.pipeline-timeline__item--completed .pipeline-timeline__marker {
-  background: var(--color-success);
-  box-shadow: 0 0 0 6px rgba(21, 128, 61, 0.12);
+.pipeline-stepper__item--success,
+.pipeline-stepper__item--completed {
+  --step-color: var(--color-success);
 }
 
 .template-grid {


### PR DESCRIPTION
## Summary
- replace the pipeline timeline markup with a numbered stepper list that exposes each entry index
- add CSS for the new stepper component including level-specific colors for info, success/completed, warning, and error states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b4c9852883338a8d7b20deefd076