### PR TITLE
feat: lay out pipeline stepper horizontally

### DIFF
--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -227,21 +227,34 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
         </h3>
         {isLoadingLogs && <p className="text-base-content/70">Chargement des logs…</p>}
         {logs.length ? (
-          <ol className="pipeline-timeline" aria-label="Chronologie du pipeline">
+          <ol
+            className="pipeline-stepper pipeline-stepper--horizontal"
+            aria-label="Chronologie du pipeline"
+          >
             {logs.map((entry, index) => {
               const level = typeof entry.level === 'string' ? entry.level.toLowerCase() : 'info';
               const levelLabel = typeof entry.level === 'string' ? entry.level.toUpperCase() : 'INFO';
               return (
                 <li
                   key={`${entry.timestamp}-${index}`}
-                  className={`pipeline-timeline__item pipeline-timeline__item--${level}`}
+                  className={`pipeline-stepper__item pipeline-stepper__item--${level}`}
                 >
-                  <div className="pipeline-timeline__marker" aria-hidden="true" />
-                  <div className="pipeline-timeline__content">
-                    <div className="pipeline-timeline__meta">
+                  <div className="pipeline-stepper__head">
+                    <span
+                      className="pipeline-stepper__connector pipeline-stepper__connector--before"
+                      aria-hidden="true"
+                    />
+                    <span className="pipeline-stepper__index">{index + 1}</span>
+                    <span
+                      className="pipeline-stepper__connector pipeline-stepper__connector--after"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <div className="pipeline-stepper__body">
+                    <div className="pipeline-stepper__meta">
                       {new Date(entry.timestamp).toLocaleTimeString()} • {levelLabel}
                     </div>
-                    <div className="pipeline-timeline__message">{entry.message}</div>
+                    <div className="pipeline-stepper__message">{entry.message}</div>
                   </div>
                 </li>
               );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1412,56 +1412,105 @@ legend {
   color: var(--color-error);
 }
 
-.pipeline-timeline {
+.pipeline-stepper {
+  --pipeline-stepper-gap: 1.5rem;
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0.5rem;
+  display: flex;
+  gap: var(--pipeline-stepper-gap);
+  align-items: stretch;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.pipeline-stepper--horizontal {
+  width: 100%;
+  scroll-snap-type: x proximity;
+}
+
+.pipeline-stepper::-webkit-scrollbar {
+  height: 0.5rem;
+}
+
+.pipeline-stepper::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.pipeline-stepper::-webkit-scrollbar-thumb {
+  background: rgba(15, 23, 42, 0.2);
+  border-radius: 999px;
+}
+
+.pipeline-stepper__item,
+.pipeline-stepper__item--info {
+  --step-color: var(--color-primary);
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  align-items: stretch;
+  min-width: 240px;
+  flex: 1 0 260px;
+  gap: 0.75rem;
+  scroll-snap-align: start;
 }
 
-.pipeline-timeline__item {
+.pipeline-stepper__head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pipeline-stepper__connector {
+  flex: 1 1 auto;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--step-color);
+  background: color-mix(in srgb, var(--step-color) 45%, transparent);
+  opacity: 0.6;
+}
+
+.pipeline-stepper__item:first-child .pipeline-stepper__connector--before,
+.pipeline-stepper__item:last-child .pipeline-stepper__connector--after {
+  visibility: hidden;
+}
+
+.pipeline-stepper__index {
   position: relative;
   display: flex;
-  gap: 1rem;
-  padding-left: 0.25rem;
-}
-
-.pipeline-timeline__item::after {
-  content: '';
-  position: absolute;
-  top: 1.25rem;
-  left: 0.55rem;
-  width: 2px;
-  height: calc(100% - 1.25rem);
-  background: var(--color-border);
-}
-
-.pipeline-timeline__item:last-child::after {
-  display: none;
-}
-
-.pipeline-timeline__marker {
-  position: relative;
-  flex: 0 0 1.1rem;
-  height: 1.1rem;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 999px;
-  background: var(--color-border);
-  box-shadow: 0 0 0 6px rgba(15, 23, 42, 0.08);
-  margin-top: 0.15rem;
+  font-weight: 700;
+  font-size: 1rem;
+  background: var(--step-color);
+  background: color-mix(in srgb, var(--step-color) 18%, var(--color-surface));
+  border: 2px solid var(--step-color);
+  color: var(--color-surface);
+  box-shadow: 0 0 0 4px rgba(15, 23, 42, 0.08);
+  z-index: 1;
 }
 
-.pipeline-timeline__content {
-  flex: 1;
+@supports (background: color-mix(in srgb, white 0%, black 0%)) {
+  .pipeline-stepper__index {
+    color: var(--step-color);
+  }
+}
+
+.pipeline-stepper__body {
   border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--step-color);
+  border: 1px solid color-mix(in srgb, var(--step-color) 35%, var(--color-border));
+  padding: 0.75rem 1rem;
   background: var(--color-surface);
+  background: color-mix(in srgb, var(--step-color) 12%, var(--color-surface));
   box-shadow: var(--shadow-soft);
+  text-align: left;
 }
 
-.pipeline-timeline__meta {
+.pipeline-stepper__meta {
   font-size: 0.8rem;
   font-weight: 600;
   color: var(--color-text-muted);
@@ -1470,24 +1519,45 @@ legend {
   margin-bottom: 0.35rem;
 }
 
-.pipeline-timeline__message {
+.pipeline-stepper__message {
   font-size: 0.95rem;
 }
 
-.pipeline-timeline__item--error .pipeline-timeline__marker {
-  background: var(--color-error);
-  box-shadow: 0 0 0 6px rgba(220, 38, 38, 0.12);
+.pipeline-stepper__item--error {
+  --step-color: var(--color-error);
 }
 
-.pipeline-timeline__item--warning .pipeline-timeline__marker {
-  background: var(--color-secondary);
-  box-shadow: 0 0 0 6px rgba(246, 139, 30, 0.12);
+.pipeline-stepper__item--warning {
+  --step-color: var(--color-secondary);
 }
 
-.pipeline-timeline__item--success .pipeline-timeline__marker,
-.pipeline-timeline__item--completed .pipeline-timeline__marker {
-  background: var(--color-success);
-  box-shadow: 0 0 0 6px rgba(21, 128, 61, 0.12);
+.pipeline-stepper__item--success,
+.pipeline-stepper__item--completed {
+  --step-color: var(--color-success);
+}
+
+@media (max-width: 1024px) {
+  .pipeline-stepper {
+    --pipeline-stepper-gap: 1.25rem;
+  }
+
+  .pipeline-stepper__item,
+  .pipeline-stepper__item--info {
+    min-width: 220px;
+    flex-basis: 240px;
+  }
+}
+
+@media (max-width: 640px) {
+  .pipeline-stepper {
+    --pipeline-stepper-gap: 1rem;
+  }
+
+  .pipeline-stepper__item,
+  .pipeline-stepper__item--info {
+    min-width: 200px;
+    flex-basis: 220px;
+  }
 }
 
 .template-grid {


### PR DESCRIPTION
## Summary
- restructure the pipeline log markup to support a horizontal numbered stepper with connectors
- add horizontal stepper styles with scrollable layout, connectors, and level-specific colors for each pipeline level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b4c9852883338a8d7b20deefd076