### PR TITLE
fix: compact pipeline stepper log display

### DIFF
--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -227,21 +227,22 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
         </h3>
         {isLoadingLogs && <p className="text-base-content/70">Chargement des logs…</p>}
         {logs.length ? (
-          <ol className="pipeline-timeline" aria-label="Chronologie du pipeline">
+          <ol className="pipeline-stepper pipeline-stepper--compact" aria-label="Chronologie du pipeline">
             {logs.map((entry, index) => {
               const level = typeof entry.level === 'string' ? entry.level.toLowerCase() : 'info';
-              const levelLabel = typeof entry.level === 'string' ? entry.level.toUpperCase() : 'INFO';
+              const eventDate = new Date(entry.timestamp);
+              const timestampLabel = eventDate.toLocaleString();
               return (
                 <li
                   key={`${entry.timestamp}-${index}`}
-                  className={`pipeline-timeline__item pipeline-timeline__item--${level}`}
+                  className={`pipeline-stepper__item pipeline-stepper__item--${level}`}
                 >
-                  <div className="pipeline-timeline__marker" aria-hidden="true" />
-                  <div className="pipeline-timeline__content">
-                    <div className="pipeline-timeline__meta">
-                      {new Date(entry.timestamp).toLocaleTimeString()} • {levelLabel}
-                    </div>
-                    <div className="pipeline-timeline__message">{entry.message}</div>
+                  <span className="pipeline-stepper__index" aria-hidden="true" />
+                  <div className="pipeline-stepper__body">
+                    <div className="pipeline-stepper__message">{entry.message}</div>
+                    <time className="pipeline-stepper__timestamp" dateTime={eventDate.toISOString()}>
+                      {timestampLabel}
+                    </time>
                   </div>
                 </li>
               );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1412,82 +1412,78 @@ legend {
   color: var(--color-error);
 }
 
-.pipeline-timeline {
+.pipeline-stepper {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.pipeline-stepper--compact {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
+  padding-left: 1.5rem;
 }
 
-.pipeline-timeline__item {
-  position: relative;
-  display: flex;
-  gap: 1rem;
-  padding-left: 0.25rem;
-}
-
-.pipeline-timeline__item::after {
+.pipeline-stepper--compact::before {
   content: '';
   position: absolute;
-  top: 1.25rem;
+  inset-block: 0.4rem;
   left: 0.55rem;
-  width: 2px;
-  height: calc(100% - 1.25rem);
-  background: var(--color-border);
+  width: 1px;
+  background: color-mix(in srgb, var(--color-border) 60%, transparent);
 }
 
-.pipeline-timeline__item:last-child::after {
-  display: none;
-}
-
-.pipeline-timeline__marker {
+.pipeline-stepper__item,
+.pipeline-stepper__item--info {
+  --step-color: var(--color-primary);
+  display: flex;
+  gap: 0.5rem;
   position: relative;
-  flex: 0 0 1.1rem;
-  height: 1.1rem;
-  border-radius: 999px;
-  background: var(--color-border);
-  box-shadow: 0 0 0 6px rgba(15, 23, 42, 0.08);
-  margin-top: 0.15rem;
-}
-
-.pipeline-timeline__content {
-  flex: 1;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  padding: 0.65rem 0.85rem;
-  background: var(--color-surface);
-  box-shadow: var(--shadow-soft);
-}
-
-.pipeline-timeline__meta {
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: 0.85rem;
   color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.35rem;
 }
 
-.pipeline-timeline__message {
-  font-size: 0.95rem;
+.pipeline-stepper__index {
+  flex: 0 0 auto;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--step-color) 75%, transparent);
+  border: 1px solid var(--step-color);
+  margin-top: 0.2rem;
 }
 
-.pipeline-timeline__item--error .pipeline-timeline__marker {
-  background: var(--color-error);
-  box-shadow: 0 0 0 6px rgba(220, 38, 38, 0.12);
+.pipeline-stepper__body {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-.pipeline-timeline__item--warning .pipeline-timeline__marker {
-  background: var(--color-secondary);
-  box-shadow: 0 0 0 6px rgba(246, 139, 30, 0.12);
+.pipeline-stepper__message {
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.2;
 }
 
-.pipeline-timeline__item--success .pipeline-timeline__marker,
-.pipeline-timeline__item--completed .pipeline-timeline__marker {
-  background: var(--color-success);
-  box-shadow: 0 0 0 6px rgba(21, 128, 61, 0.12);
+.pipeline-stepper__timestamp {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+
+.pipeline-stepper__item--error {
+  --step-color: var(--color-error);
+}
+
+.pipeline-stepper__item--warning {
+  --step-color: var(--color-secondary);
+}
+
+.pipeline-stepper__item--success,
+.pipeline-stepper__item--completed {
+  --step-color: var(--color-success);
 }
 
 .template-grid {


### PR DESCRIPTION
## Summary
- compress the pipeline log markup to show only the message and timestamp in a compact stack
- restyle the pipeline stepper into a slim vertical timeline with small colored markers per level

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b4c9852883338a8d7b20deefd076