### PR TITLE
feat: refresh job history delete action button

### DIFF
--- a/frontend/src/components/JobList.jsx
+++ b/frontend/src/components/JobList.jsx
@@ -98,7 +98,7 @@ export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
                         </button>
                         <button
                           type="button"
-                          className="history-row-menu__item history-row-menu__item--danger"
+                          className="history-row-menu__item history-row-menu__item--danger btn btn-error btn-with-icon"
                           role="menuitem"
                           onClick={(event) => {
                             event.stopPropagation();
@@ -112,7 +112,18 @@ export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
                             }
                           }}
                         >
-                          Supprimer
+                          <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            viewBox="0 0 20 20"
+                            className="btn-with-icon__icon"
+                          >
+                            <path
+                              d="M7 2.5A1.5 1.5 0 0 1 8.5 1h3A1.5 1.5 0 0 1 13 2.5V3h3.5a.75.75 0 0 1 0 1.5h-.638l-.74 10.013A2.25 2.25 0 0 1 12.88 16.5H7.12a2.25 2.25 0 0 1-1.742-.987L4.638 4.5H4a.75.75 0 0 1 0-1.5H7V2.5Zm1.5-.25a.25.25 0 0 0-.25.25V3h3.5v-.5a.25.25 0 0 0-.25-.25h-3Zm4.37 4.25a.75.75 0 0 1 1.495.11l-.427 6a.75.75 0 0 1-1.497-.107l.43-6.003Zm-4.508-.64a.75.75 0 0 1 .858.624l.73 6a.75.75 0 0 1-1.49.182l-.73-6a.75.75 0 0 1 .632-.806ZM6.03 6.36a.75.75 0 0 1 1.494.214l-.43 6.003a.75.75 0 0 1-1.496-.107l.432-6.11ZM6.25 4.5l-.33 4.66-.311 4.202a.75.75 0 0 0 .581.79c.417.09.846.135 1.276.135h5.004c.43 0 .859-.045 1.276-.135a.75.75 0 0 0 .58-.79l-.64-8.862H6.25Z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                          <span>Supprimer</span>
                         </button>
                       </div>
                     )}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -643,10 +643,12 @@ textarea {
 .btn-error {
   background: var(--color-error);
   color: #fff;
+  box-shadow: 0 16px 30px -20px rgba(220, 38, 38, 0.6);
 }
 
 .btn-error:hover {
   background: #b91c1c;
+  color: #fff;
 }
 
 .btn-xs {
@@ -1624,6 +1626,7 @@ fieldset + fieldset {
 .history-row-menu__item {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.5rem;
   width: 100%;
   padding: 0.45rem 0.75rem;
@@ -1635,6 +1638,7 @@ fieldset + fieldset {
   font-weight: 500;
   cursor: pointer;
   text-align: left;
+  transform: none;
 }
 
 .history-row-menu__item:hover,
@@ -1654,6 +1658,34 @@ fieldset + fieldset {
 .history-row-menu__item--danger:hover,
 .history-row-menu__item--danger:focus-visible {
   background: rgba(220, 38, 38, 0.12);
+}
+
+.history-row-menu__item.btn {
+  box-shadow: none;
+  border: none;
+  padding: 0.45rem 0.75rem;
+  width: 100%;
+  transform: none;
+}
+
+.history-row-menu__item.btn:hover {
+  background: rgba(0, 58, 99, 0.08);
+  transform: none;
+}
+
+.history-row-menu__item.btn-error {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--color-error);
+}
+
+.history-row-menu__item.btn-error:hover,
+.history-row-menu__item.btn-error:focus-visible {
+  background: rgba(220, 38, 38, 0.2);
+  color: var(--color-error);
+}
+
+.history-row-menu__item.btn-error .btn-with-icon__icon {
+  color: currentColor;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- replace the job history delete action with an icon-friendly button and add a trash pictogram
- adjust the error button styling so the icon and label align correctly in the action menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7fba1dcd483338049fe33e4bb0eb3