### PR TITLE
Auto-select job summary export

### DIFF
--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -35,6 +35,29 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   }, [jobId]);
 
   useEffect(() => {
+    if (!outputs.length || selectedOutput) {
+      return;
+    }
+
+    const summaryOutput = outputs.find((output) => {
+      if (output.filename === 'summary.md') {
+        return true;
+      }
+      const mimeType = output.mimeType?.toLowerCase();
+      return mimeType === 'text/markdown';
+    });
+
+    const nextOutput = summaryOutput ?? outputs[0];
+    if (nextOutput) {
+      setSelectedOutput({
+        filename: nextOutput.filename,
+        label: nextOutput.label,
+        mimeType: nextOutput.mimeType,
+      });
+    }
+  }, [outputs, selectedOutput]);
+
+  useEffect(() => {
     if (!selectedOutputFilename) {
       return;
     }


### PR DESCRIPTION
## Summary
- automatically select the summary markdown export when a new job is opened
- fall back to the first available export so the preview always shows content
- rely on the existing fetch effect to load the auto-selected export

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fd23e2d8833395a03d53d12650e2