### PR TITLE
Support dropup placement for job menu

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1621,6 +1621,11 @@ fieldset + fieldset {
   z-index: 20;
 }
 
+.history-row-menu__content--dropup {
+  top: auto;
+  bottom: calc(100% + 0.35rem);
+}
+
 .history-row-menu__item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- detect when the job row action menu would overflow the viewport and apply a dropup modifier
- add styling for the dropup variant so the menu opens upward when required

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d7ffb3ed648333b57ff228bccce9b0