### PR TITLE
feat: transform participant input into removable badges

### DIFF
--- a/frontend/src/components/UploadForm.jsx
+++ b/frontend/src/components/UploadForm.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 export default function UploadForm({ templates, onSubmit }) {
   const [file, setFile] = useState(null);
-  const [participants, setParticipants] = useState('');
+  const [participants, setParticipants] = useState([]);
+  const [participantInput, setParticipantInput] = useState('');
   const [templateId, setTemplateId] = useState(templates[0]?.id || '');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState(null);
@@ -24,19 +25,55 @@ export default function UploadForm({ templates, onSubmit }) {
     setError(null);
     setIsSubmitting(true);
     try {
+      const trimmedPendingParticipant = participantInput.trim();
+      const hasPendingParticipant = Boolean(trimmedPendingParticipant);
+      const nextParticipants = hasPendingParticipant
+        ? participants.includes(trimmedPendingParticipant)
+          ? participants
+          : [...participants, trimmedPendingParticipant]
+        : participants;
+
       const formData = new FormData();
       formData.append('file', file);
-      formData.append('participants', participants);
+      formData.append('participants', nextParticipants.join(', '));
       formData.append('templateId', templateId);
       await onSubmit(formData);
       setFile(null);
-      setParticipants('');
+      setParticipants([]);
+      setParticipantInput('');
       setTemplateId(templateOptions[0]?.value || '');
     } catch (err) {
       setError(err.message);
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleAddParticipant = (value) => {
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+      return;
+    }
+    setParticipants((currentParticipants) => {
+      if (currentParticipants.includes(trimmedValue)) {
+        return currentParticipants;
+      }
+      return [...currentParticipants, trimmedValue];
+    });
+  };
+
+  const handleParticipantKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleAddParticipant(participantInput);
+      setParticipantInput('');
+    }
+  };
+
+  const handleRemoveParticipant = (indexToRemove) => {
+    setParticipants((currentParticipants) =>
+      currentParticipants.filter((_, index) => index !== indexToRemove),
+    );
   };
 
   return (
@@ -66,16 +103,35 @@ export default function UploadForm({ templates, onSubmit }) {
 
         <div className="form-field">
           <label className="form-label" htmlFor="participants">
-            Participants (séparés par une virgule)
+            Participants
           </label>
           <input
             id="participants"
             className="input input-bordered"
             type="text"
-            placeholder="Alice, Bob, ..."
-            value={participants}
-            onChange={(event) => setParticipants(event.target.value)}
+            placeholder="Ajoutez un participant et appuyez sur Entrée"
+            value={participantInput}
+            onChange={(event) => setParticipantInput(event.target.value)}
+            onKeyDown={handleParticipantKeyDown}
           />
+          <p className="form-helper">Appuyez sur Entrée pour ajouter un participant.</p>
+          {participants.length > 0 && (
+            <div className="participant-badge-list" role="list">
+              {participants.map((participant, index) => (
+                <span className="participant-badge" key={participant} role="listitem">
+                  <span>{participant}</span>
+                  <button
+                    type="button"
+                    className="participant-badge__remove"
+                    onClick={() => handleRemoveParticipant(index)}
+                    aria-label={`Retirer ${participant}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="form-field">

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -951,6 +951,42 @@ pre {
   color: var(--color-text-muted);
 }
 
+.participant-badge-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.participant-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  box-shadow: 0 8px 18px -12px rgba(0, 58, 99, 0.75);
+}
+
+.participant-badge__remove {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.participant-badge__remove:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
 .chip-list {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- replace the participants text box with badge-based entry triggered on Enter and deduplicate pending entries
- allow participants to be removed directly from the form before submission
- add styling so participant badges reuse the interface primary blue color

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8070908e08333b3661fc2d90dedf6