### PR TITLE
Adjust navbar button placement and tab behavior

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -130,9 +130,7 @@ function AppShell() {
 
   const handleTabChange = (tabId) => {
     setActiveTab(tabId);
-    if (tabId !== 'jobs') {
-      setIsCreatingJob(false);
-    }
+    setIsCreatingJob(false);
   };
 
   return (
@@ -143,6 +141,27 @@ function AppShell() {
           <p className="home-subtitle">Traitement audio local avec résumés assistés OpenAI</p>
         </div>
         <nav className="navbar" aria-label="Navigation principale">
+          <button
+            type="button"
+            className="btn btn-primary btn-sm btn-with-icon"
+            onClick={() => {
+              setActiveTab('jobs');
+              setIsCreatingJob((prev) => (activeTab === 'jobs' ? !prev : true));
+            }}
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              viewBox="0 0 20 20"
+              className="btn-with-icon__icon"
+            >
+              <path
+                d="M10 4a1 1 0 0 1 1 1v4h4a1 1 0 1 1 0 2h-4v4a1 1 0 1 1-2 0v-4H5a1 1 0 1 1 0-2h4V5a1 1 0 0 1 1-1Z"
+                fill="currentColor"
+              />
+            </svg>
+            {isCreatingJob ? 'Fermer' : 'Nouveau traitement'}
+          </button>
           <div className="navbar-tabs" role="tablist">
             {TABS.map((tab) => {
               const isActive = tab.id === activeTab;
@@ -162,29 +181,6 @@ function AppShell() {
                 </button>
               );
             })}
-          </div>
-          <div className="navbar-actions">
-            <button
-              type="button"
-              className="btn btn-primary btn-sm btn-with-icon"
-              onClick={() => {
-                setActiveTab('jobs');
-                setIsCreatingJob((prev) => (activeTab === 'jobs' ? !prev : true));
-              }}
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                viewBox="0 0 20 20"
-                className="btn-with-icon__icon"
-              >
-                <path
-                  d="M10 4a1 1 0 0 1 1 1v4h4a1 1 0 1 1 0 2h-4v4a1 1 0 1 1-2 0v-4H5a1 1 0 1 1 0-2h4V5a1 1 0 0 1 1-1Z"
-                  fill="currentColor"
-                />
-              </svg>
-              {isCreatingJob ? 'Fermer' : 'Nouveau traitement'}
-            </button>
           </div>
         </nav>
       </header>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -71,13 +71,6 @@ textarea {
 }
 
 .navbar-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.navbar-actions {
   margin-left: auto;
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- move the "Nouveau traitement" button before the tab list so it stays on the left of the navbar
- ensure switching tabs always closes the creation form and keep job tabs aligned to the right by updating styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8089c912c8333b31886d3aa34d612