### PR TITLE
Adjust dropup detection for job menu alignment

### DIFF
--- a/frontend/src/components/JobList.jsx
+++ b/frontend/src/components/JobList.jsx
@@ -48,7 +48,11 @@ export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
 
     const rect = contentElement.getBoundingClientRect();
     const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-    const shouldDropup = rect.bottom > viewportHeight;
+    const containerElement =
+      menuElement.closest('.surface-card') || menuElement.closest('[data-dropup-container]');
+    const containerRect = containerElement?.getBoundingClientRect();
+    const bottomLimit = Math.min(viewportHeight, containerRect?.bottom ?? viewportHeight);
+    const shouldDropup = rect.bottom > bottomLimit;
 
     setOpenMenu((current) => {
       if (current.id !== menuId || current.dropup === shouldDropup) {


### PR DESCRIPTION
## Summary
- compute the dropup state by comparing the menu against both the viewport and its containing surface
- ensure the dropup class remains applied when the menu needs to open upward

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80bb09e388333a953e0018b7c3c29