### PR TITLE
feat: display job summary in job detail view

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1342,6 +1342,84 @@ legend {
   border: 1px solid var(--color-border);
 }
 
+.summary-preview {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  padding: 1.5rem;
+  max-height: 24rem;
+  overflow-y: auto;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  line-height: 1.75;
+}
+
+.summary-preview h1,
+.summary-preview h2,
+.summary-preview h3,
+.summary-preview h4,
+.summary-preview h5,
+.summary-preview h6 {
+  margin: 0 0 0.85rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.summary-preview h1 {
+  font-size: 1.5rem;
+}
+
+.summary-preview h2 {
+  font-size: 1.35rem;
+}
+
+.summary-preview h3 {
+  font-size: 1.2rem;
+}
+
+.summary-preview p + p,
+.summary-preview p + ul,
+.summary-preview p + ol,
+.summary-preview ul + p,
+.summary-preview ol + p {
+  margin-top: 0.85rem;
+}
+
+.summary-preview ul,
+.summary-preview ol {
+  padding-left: 1.25rem;
+  margin: 0.85rem 0;
+}
+
+.summary-preview li + li {
+  margin-top: 0.45rem;
+}
+
+.summary-preview pre {
+  background: var(--color-app-bg);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.summary-preview code {
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 0.375rem;
+  padding: 0.1rem 0.35rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.summary-preview a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
 fieldset + fieldset {
   margin-top: 1.5rem;
 }

--- a/frontend/src/utils/renderMarkdown.js
+++ b/frontend/src/utils/renderMarkdown.js
@@ -1,0 +1,131 @@
+const LIST_ITEM_REGEX = /^(\s*)([-*+] |\d+\. )(.*)$/;
+
+function escapeHtml(value = '') {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderInline(text = '') {
+  let escaped = escapeHtml(text);
+  escaped = escaped.replace(/\[(.+?)\]\((.+?)\)/g, (_, label, href) => {
+    const safeHref = escapeHtml(href.trim());
+    const safeLabel = escapeHtml(label.trim());
+    if (!safeHref) {
+      return safeLabel;
+    }
+    return `<a href="${safeHref}" target="_blank" rel="noreferrer">${safeLabel}</a>`;
+  });
+  escaped = escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  escaped = escaped.replace(/__(.+?)__/g, '<strong>$1</strong>');
+  escaped = escaped.replace(/(^|[^*])\*(?!\s)(.+?)(?!\s)\*(?!\*)/g, '$1<em>$2</em>');
+  escaped = escaped.replace(/(^|[^_])_(?!\s)(.+?)(?!\s)_(?!_)/g, '$1<em>$2</em>');
+  escaped = escaped.replace(/`([^`]+)`/g, '<code>$1</code>');
+  return escaped;
+}
+
+export function renderMarkdown(markdown = '') {
+  if (!markdown || !markdown.trim()) {
+    return '';
+  }
+
+  const lines = markdown.replace(/\r\n?/g, '\n').split('\n');
+  const html = [];
+  let paragraphBuffer = [];
+  let inCodeBlock = false;
+  let codeBuffer = [];
+  let listType = null;
+  let listDepth = 0;
+
+  const flushParagraph = () => {
+    if (paragraphBuffer.length) {
+      const text = paragraphBuffer.join(' ').trim();
+      if (text) {
+        html.push(`<p>${renderInline(text)}</p>`);
+      }
+      paragraphBuffer = [];
+    }
+  };
+
+  const closeList = () => {
+    while (listDepth > 0) {
+      const tagName = listType === 'ol' ? 'ol' : 'ul';
+      html.push(`</${tagName}>`);
+      listDepth -= 1;
+    }
+    listType = null;
+  };
+
+  const flushCode = () => {
+    if (inCodeBlock) {
+      html.push(`<pre><code>${codeBuffer.join('\n')}</code></pre>`);
+      inCodeBlock = false;
+      codeBuffer = [];
+    }
+  };
+
+  lines.forEach((rawLine) => {
+    const line = rawLine;
+    if (line.trim().startsWith('```')) {
+      if (inCodeBlock) {
+        flushCode();
+      } else {
+        flushParagraph();
+        closeList();
+        inCodeBlock = true;
+        codeBuffer = [];
+      }
+      return;
+    }
+
+    if (inCodeBlock) {
+      codeBuffer.push(escapeHtml(line));
+      return;
+    }
+
+    if (!line.trim()) {
+      flushParagraph();
+      closeList();
+      return;
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      flushParagraph();
+      closeList();
+      const level = Math.min(6, headingMatch[1].length);
+      html.push(`<h${level}>${renderInline(headingMatch[2].trim())}</h${level}>`);
+      return;
+    }
+
+    const listMatch = line.match(LIST_ITEM_REGEX);
+    if (listMatch) {
+      const isOrdered = /\d+\. /.test(listMatch[2]);
+      const desiredListType = isOrdered ? 'ol' : 'ul';
+      if (listType !== desiredListType) {
+        closeList();
+        listType = desiredListType;
+        listDepth = 0;
+      }
+      if (listDepth === 0) {
+        html.push(`<${listType}>`);
+      }
+      listDepth = 1;
+      flushParagraph();
+      const content = listMatch[3];
+      html.push(`<li>${renderInline(content.trim())}</li>`);
+      return;
+    }
+
+    paragraphBuffer.push(line.trim());
+  });
+
+  flushParagraph();
+  closeList();
+  flushCode();
+
+  return html.join('\n').trim();
+}


### PR DESCRIPTION
## Summary
- fetch the summary markdown asset when a job exposes `summary.md`
- render the summary with loading, error, and empty states using a lightweight markdown renderer
- add dedicated styling so the summary preview matches the rest of the history detail UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6f561423c8333853102f5b5159bf9