### PR TITLE
Add routing for job history view

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.21",

--- a/frontend/src/components/JobDashboard.jsx
+++ b/frontend/src/components/JobDashboard.jsx
@@ -1,38 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+import { useOutletContext } from 'react-router-dom';
 import JobList from './JobList.jsx';
-import JobDetail from './JobDetail.jsx';
-import { api } from '../api/client.js';
 
-export default function JobDashboard({ jobs, selectedJob, onSelectJob, onDeleteJob }) {
-  const [logs, setLogs] = useState([]);
-  const [isLoadingLogs, setIsLoadingLogs] = useState(false);
-
-  useEffect(() => {
-    let isMounted = true;
-    if (!selectedJob) {
-      setLogs([]);
-      return () => {
-        isMounted = false;
-      };
-    }
-    async function fetchLogs() {
-      setIsLoadingLogs(true);
-      try {
-        const entries = await api.getJobLogs(selectedJob.id);
-        if (isMounted) setLogs(entries);
-      } catch (error) {
-        if (isMounted) setLogs([{ message: error.message, level: 'error', timestamp: new Date().toISOString() }]);
-      } finally {
-        if (isMounted) setIsLoadingLogs(false);
-      }
-    }
-    fetchLogs();
-    const interval = setInterval(fetchLogs, 5000);
-    return () => {
-      isMounted = false;
-      clearInterval(interval);
-    };
-  }, [selectedJob]);
+export default function JobDashboard() {
+  const { jobs, onDeleteJob } = useOutletContext();
 
   return (
     <section className="history-stack">
@@ -41,15 +12,7 @@ export default function JobDashboard({ jobs, selectedJob, onSelectJob, onDeleteJ
           <h2 className="section-title">Historique des traitements</h2>
           <p className="text-base-content/70 text-sm">{jobs.length} traitement(s) enregistré(s)</p>
         </div>
-        <JobList jobs={jobs} selectedJob={selectedJob} onSelect={onSelectJob} onDelete={onDeleteJob} />
-      </div>
-      <div className="surface-card history-detail-card">
-        <JobDetail
-          job={selectedJob}
-          logs={logs}
-          isLoadingLogs={isLoadingLogs}
-          onDeleteJob={onDeleteJob}
-        />
+        <JobList jobs={jobs} onDelete={onDeleteJob} />
       </div>
     </section>
   );

--- a/frontend/src/components/JobList.jsx
+++ b/frontend/src/components/JobList.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import StatusBadge from './StatusBadge.jsx';
 
-export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
+export default function JobList({ jobs, onDelete }) {
   const [openMenu, setOpenMenu] = useState({ id: null, dropup: false });
   const menuRefs = useRef(new Map());
 
@@ -81,33 +82,35 @@ export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
         </thead>
         <tbody>
           {jobs.map((job) => {
-            const isActive = selectedJob?.id === job.id;
             const progressValue = Math.round(job.progress ?? 0);
             const isMenuOpen = openMenu.id === job.id;
             const isDropup = isMenuOpen && openMenu.dropup;
+            const jobDetailPath = `/jobs/${job.id}`;
             return (
-              <tr
-                key={job.id}
-                className={isActive ? 'history-row--active' : undefined}
-                onClick={() => onSelect(job.id)}
-              >
+              <tr key={job.id}>
                 <td>
-                  <div className="font-medium">{job.filename}</div>
-                  <div className="text-base-content/70 text-sm">
-                    Créé le {new Date(job.createdAt).toLocaleString()}
-                    {job.participants?.length ? ` • Participants : ${job.participants.join(', ')}` : ''}
-                  </div>
-                </td>
-                <td>
-                  <StatusBadge status={job.status} />
-                </td>
-                <td>
-                  <div className="status-progress" aria-label="Avancement du traitement">
-                    <div className="progress-bar" role="presentation">
-                      <div className="progress-bar__value" style={{ width: `${progressValue}%` }} />
+                  <Link to={jobDetailPath} className="history-row__link">
+                    <div className="font-medium">{job.filename}</div>
+                    <div className="text-base-content/70 text-sm">
+                      Créé le {new Date(job.createdAt).toLocaleString()}
+                      {job.participants?.length ? ` • Participants : ${job.participants.join(', ')}` : ''}
                     </div>
-                    <span className="status-progress-value">{progressValue}%</span>
-                  </div>
+                  </Link>
+                </td>
+                <td>
+                  <Link to={jobDetailPath} className="history-row__link history-row__link--inline">
+                    <StatusBadge status={job.status} />
+                  </Link>
+                </td>
+                <td>
+                  <Link to={jobDetailPath} className="history-row__link history-row__link--inline">
+                    <div className="status-progress" aria-label="Avancement du traitement">
+                      <div className="progress-bar" role="presentation">
+                        <div className="progress-bar__value" style={{ width: `${progressValue}%` }} />
+                      </div>
+                      <span className="status-progress-value">{progressValue}%</span>
+                    </div>
+                  </Link>
                 </td>
                 <td className="history-row-menu-cell">
                   <div className="history-row-menu" ref={registerMenuRef(job.id)}>
@@ -135,18 +138,17 @@ export default function JobList({ jobs, selectedJob, onSelect, onDelete }) {
                         }`}
                         role="menu"
                       >
-                        <button
-                          type="button"
+                        <Link
+                          to={jobDetailPath}
                           className="history-row-menu__item"
                           role="menuitem"
                           onClick={(event) => {
                             event.stopPropagation();
                             setOpenMenu({ id: null, dropup: false });
-                            onSelect(job.id);
                           }}
                         >
                           Voir le détail
-                        </button>
+                        </Link>
                         <button
                           type="button"
                           className="history-row-menu__item history-row-menu__item--danger"

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,24 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App.jsx';
+import JobDashboard from './components/JobDashboard.jsx';
+import JobDetailPage from './pages/JobDetailPage.jsx';
 import './styles/global.css';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      { index: true, element: <JobDashboard /> },
+      { path: 'jobs/:id', element: <JobDetailPage /> },
+    ],
+  },
+]);
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 );

--- a/frontend/src/pages/JobDetailPage.jsx
+++ b/frontend/src/pages/JobDetailPage.jsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate, useOutletContext, useParams } from 'react-router-dom';
+import JobDetail from '../components/JobDetail.jsx';
+import { api } from '../api/client.js';
+import { useAppContext } from '../context/AppContext.jsx';
+
+function findJobById(jobs, id) {
+  return jobs.find((item) => String(item.id) === String(id)) ?? null;
+}
+
+export default function JobDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { jobs, setJobs } = useAppContext();
+  const { onDeleteJob } = useOutletContext();
+  const [job, setJob] = useState(() => findJobById(jobs, id));
+  const [isLoadingJob, setIsLoadingJob] = useState(() => !findJobById(jobs, id));
+  const [jobError, setJobError] = useState(null);
+  const [logs, setLogs] = useState([]);
+  const [isLoadingLogs, setIsLoadingLogs] = useState(false);
+
+  const jobId = job ? job.id : id;
+
+  useEffect(() => {
+    const existing = findJobById(jobs, id);
+    if (existing) {
+      setJob(existing);
+      setIsLoadingJob(false);
+      setJobError(null);
+    } else if (!isLoadingJob && !jobError) {
+      setJob(null);
+      setJobError("Ce traitement n'est plus disponible.");
+    }
+  }, [jobs, id, isLoadingJob, jobError]);
+
+  useEffect(() => {
+    if (findJobById(jobs, id)) {
+      return undefined;
+    }
+    let isMounted = true;
+    setIsLoadingJob(true);
+    setJobError(null);
+
+    async function fetchJob() {
+      try {
+        const jobData = await api.getJob(id);
+        if (!isMounted) return;
+        setJob(jobData);
+        setJobs((current) => {
+          const hasJob = current.some((item) => String(item.id) === String(jobData.id));
+          if (hasJob) {
+            return current.map((item) => (String(item.id) === String(jobData.id) ? jobData : item));
+          }
+          return [jobData, ...current];
+        });
+      } catch (error) {
+        if (isMounted) {
+          const message = error instanceof Error ? error.message : "Impossible de charger ce traitement.";
+          setJobError(message);
+          setJob(null);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoadingJob(false);
+        }
+      }
+    }
+
+    fetchJob();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [id, jobs, setJobs]);
+
+  useEffect(() => {
+    if (!jobId || !job) {
+      setLogs([]);
+      setIsLoadingLogs(false);
+      return undefined;
+    }
+
+    let isMounted = true;
+    let initialFetch = true;
+
+    async function fetchLogs() {
+      if (initialFetch) {
+        setIsLoadingLogs(true);
+      }
+      try {
+        const entries = await api.getJobLogs(jobId);
+        if (isMounted) {
+          setLogs(entries);
+        }
+      } catch (error) {
+        if (isMounted) {
+          const message = error instanceof Error ? error.message : "Impossible de charger les logs.";
+          setLogs([
+            {
+              message,
+              level: 'error',
+              timestamp: new Date().toISOString(),
+            },
+          ]);
+        }
+      } finally {
+        if (isMounted && initialFetch) {
+          setIsLoadingLogs(false);
+          initialFetch = false;
+        }
+      }
+    }
+
+    fetchLogs();
+    const interval = setInterval(fetchLogs, 5000);
+
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
+  }, [jobId, job]);
+
+  const handleDeleteAndReturn = async (jobToDelete) => {
+    try {
+      await onDeleteJob?.(jobToDelete);
+      navigate('/');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "La suppression a échoué.";
+      setJobError(message);
+    }
+  };
+
+  return (
+    <section className="history-stack">
+      <div className="surface-card history-detail-card">
+        <div className="history-detail-toolbar">
+          <Link to="/" className="btn btn-secondary btn-sm">
+            Retour à l'historique
+          </Link>
+        </div>
+        {isLoadingJob ? (
+          <p className="text-base-content/70">Chargement du traitement…</p>
+        ) : jobError ? (
+          <div className="space-y-4">
+            <div role="alert" className="alert alert--error">
+              {jobError}
+            </div>
+            <p className="text-base-content/70">
+              Utilisez le bouton ci-dessus pour revenir à l'historique des traitements.
+            </p>
+          </div>
+        ) : (
+          <JobDetail job={job} logs={logs} isLoadingLogs={isLoadingLogs} onDeleteJob={handleDeleteAndReturn} />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1337,7 +1337,7 @@ pre {
 }
 
 .history-table tbody tr {
-  cursor: pointer;
+  cursor: default;
   transition: background-color 0.2s ease;
 }
 
@@ -1347,6 +1347,46 @@ pre {
 
 .history-row--active {
   background: rgba(0, 58, 99, 0.12);
+}
+
+.history-row__link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.history-row__link:hover,
+.history-row__link:focus-visible {
+  text-decoration: none;
+}
+
+.history-row__link:hover .font-medium,
+.history-row__link:focus-visible .font-medium {
+  text-decoration: underline;
+}
+
+.history-row__link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.history-row__link--inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
+.history-row__link--inline:hover,
+.history-row__link--inline:focus-visible {
+  text-decoration: none;
+}
+
+.history-row__link--inline:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .history-empty {
@@ -1364,6 +1404,13 @@ pre {
 
 .history-detail-card {
   padding: 1.75rem;
+}
+
+.history-detail-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
 }
 
 .history-detail-header {
@@ -1669,6 +1716,7 @@ fieldset + fieldset {
   font-weight: 500;
   cursor: pointer;
   text-align: left;
+  text-decoration: none;
 }
 
 .history-row-menu__item:hover,


### PR DESCRIPTION
## Summary
- add react-router-dom to the frontend and wire a router in main.jsx
- introduce a JobDetailPage that loads job data/logs and reuses the existing JobDetail component with a back link
- refactor the dashboard/list to link to detail routes and adjust styles for the new navigation flow

## Testing
- not run (react-router-dom install blocked by registry proxy)


------
https://chatgpt.com/codex/tasks/task_e_68d80cce0378833385630195de9231dd