### PR TITLE
feat: render markdown exports in job detail

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.0"
+    "react-router-dom": "^6.22.0",
+    "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.21",

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { API_BASE } from '../api/client.js';
 import StatusBadge from './StatusBadge.jsx';
 
@@ -59,6 +61,17 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   const outputs = useMemo(() => job?.outputs ?? [], [job?.outputs]);
   const selectedOutputFilename = selectedOutput?.filename ?? null;
   const selectedOutputMime = selectedOutput?.mimeType ?? null;
+  const isMarkdownContent = useMemo(() => {
+    if (!selectedOutput) {
+      return false;
+    }
+    const mimeType = selectedOutput.mimeType?.toLowerCase() ?? '';
+    if (mimeType.includes('markdown')) {
+      return true;
+    }
+    const filename = selectedOutput.filename?.toLowerCase() ?? '';
+    return filename.endsWith('.md');
+  }, [selectedOutput]);
   const canPreviewOutput = selectedOutput ? canPreviewMimeType(selectedOutputMime) : false;
 
   useEffect(() => {
@@ -295,7 +308,15 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
               </p>
             )}
             {!isLoadingOutput && !outputError && canPreviewOutput && (
-              <pre className="resource-preview__content">{outputContent}</pre>
+              isMarkdownContent ? (
+                <div className="resource-preview__content resource-preview__content--markdown">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} linkTarget="_blank">
+                    {outputContent}
+                  </ReactMarkdown>
+                </div>
+              ) : (
+                <pre className="resource-preview__content">{outputContent}</pre>
+              )
             )}
           </div>
         )}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1244,6 +1244,83 @@ pre {
   white-space: pre-wrap;
 }
 
+.resource-preview__content--markdown {
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.7;
+  white-space: normal;
+}
+
+.resource-preview__content--markdown > *:first-child {
+  margin-top: 0;
+}
+
+.resource-preview__content--markdown h1,
+.resource-preview__content--markdown h2,
+.resource-preview__content--markdown h3,
+.resource-preview__content--markdown h4,
+.resource-preview__content--markdown h5,
+.resource-preview__content--markdown h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.resource-preview__content--markdown h1 {
+  font-size: 1.6rem;
+}
+
+.resource-preview__content--markdown h2 {
+  font-size: 1.4rem;
+}
+
+.resource-preview__content--markdown h3 {
+  font-size: 1.2rem;
+}
+
+.resource-preview__content--markdown p {
+  margin: 0 0 1rem;
+}
+
+.resource-preview__content--markdown ul,
+.resource-preview__content--markdown ol {
+  margin: 0 0 1rem;
+  padding-left: 1.5rem;
+}
+
+.resource-preview__content--markdown li + li {
+  margin-top: 0.5rem;
+}
+
+.resource-preview__content--markdown a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  word-break: break-word;
+}
+
+.resource-preview__content--markdown pre {
+  margin: 0 0 1.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(17, 24, 39, 0.9);
+  color: #f9fafb;
+  overflow-x: auto;
+}
+
+.resource-preview__content--markdown code {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: 0.35rem;
+  padding: 0.15rem 0.35rem;
+}
+
+.resource-preview__content--markdown pre code {
+  background: transparent;
+  padding: 0;
+}
+
 .audio-preview {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add react-markdown and remark-gfm as frontend dependencies
- render markdown exports with ReactMarkdown when appropriate
- refine preview styles to display formatted markdown content clearly

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d811f1dc088333ba8d1ac59433bbcf