### PR TITLE
Disable deletion controls while jobs are processing

### DIFF
--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -186,6 +186,7 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   }
 
   const progressValue = Math.round(job.progress ?? 0);
+  const isProcessing = job.status === 'queued' || job.status === 'processing';
   const formattedProcessingDuration = useMemo(() => {
     if (!job) {
       return null;
@@ -211,7 +212,11 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
           <button
             type="button"
             className="history-delete-btn btn btn-error btn-md btn-with-icon"
+            disabled={isProcessing}
             onClick={() => {
+              if (isProcessing) {
+                return;
+              }
               if (
                 window.confirm(
                   'Voulez-vous vraiment supprimer ce traitement ? Cette action est irréversible.'

--- a/frontend/src/components/JobList.jsx
+++ b/frontend/src/components/JobList.jsx
@@ -86,6 +86,7 @@ export default function JobList({ jobs, onDelete }) {
             const isMenuOpen = openMenu.id === job.id;
             const isDropup = isMenuOpen && openMenu.dropup;
             const jobDetailPath = `/jobs/${job.id}`;
+            const isProcessing = job.status === 'queued' || job.status === 'processing';
             return (
               <tr key={job.id}>
                 <td>
@@ -151,10 +152,16 @@ export default function JobList({ jobs, onDelete }) {
                         </Link>
                         <button
                           type="button"
-                          className="history-row-menu__item history-row-menu__item--danger"
+                          className={`history-row-menu__item history-row-menu__item--danger${
+                            isProcessing ? ' is-disabled' : ''
+                          }`}
                           role="menuitem"
+                          disabled={isProcessing}
                           onClick={(event) => {
                             event.stopPropagation();
+                            if (isProcessing) {
+                              return;
+                            }
                             setOpenMenu({ id: null, dropup: false });
                             if (
                               window.confirm(

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1513,6 +1513,12 @@ pre {
   box-shadow: var(--shadow-soft);
 }
 
+.history-delete-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
 .history-detail {
   display: flex;
   flex-direction: column;
@@ -1808,6 +1814,26 @@ fieldset + fieldset {
 
 .history-row-menu__item--danger {
   color: var(--color-error);
+}
+
+.history-row-menu__item[disabled],
+.history-row-menu__item.is-disabled {
+  cursor: not-allowed;
+  color: var(--color-text-muted);
+  background: rgba(31, 41, 55, 0.08);
+}
+
+.history-row-menu__item--danger[disabled],
+.history-row-menu__item--danger.is-disabled {
+  color: rgba(220, 38, 38, 0.6);
+}
+
+.history-row-menu__item[disabled]:hover,
+.history-row-menu__item[disabled]:focus-visible,
+.history-row-menu__item.is-disabled:hover,
+.history-row-menu__item.is-disabled:focus-visible {
+  background: rgba(31, 41, 55, 0.08);
+  box-shadow: none;
 }
 
 .history-row-menu__item--danger:hover,


### PR DESCRIPTION
## Summary
- disable history menu deletion when a job is queued or processing
- prevent deleting jobs from the detail view while processing
- add muted styling for disabled menu items and delete buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8166c13d08333aa03402d946b12ff