### PR TITLE
Fix jobs tab navigation redirection

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -124,7 +124,7 @@ function AppShell() {
   const handleTabChange = (tabId) => {
     setActiveTab(tabId);
     setIsCreatingJob(false);
-    if (tabId !== 'jobs') {
+    if (location.pathname !== '/') {
       navigate('/');
     }
   };


### PR DESCRIPTION
## Summary
- ensure the jobs tab redirects back to the list when the current route is not the home page
- avoid redundant redirects when already on the jobs list by checking the current location

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d817270718833381332707c35784f0