### PR TITLE
Adjust home header title spacing

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -102,6 +102,10 @@ textarea {
   letter-spacing: -0.01em;
 }
 
+.home-header .page-title {
+  margin-bottom: 0.25rem;
+}
+
 .section-title {
   margin: 0 0 1rem;
   font-size: 1.25rem;


### PR DESCRIPTION
## Summary
- reduce the bottom margin of the home page title so the subtitle sits directly below it
- scope the adjustment to the home header to avoid affecting other pages

## Testing
- Not run (frontend dependencies cannot be installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d817873ff48333ac17b51a1c97d9a1