### PR TITLE
Align template manager table with history styles

### DIFF
--- a/frontend/src/components/TemplateManager.jsx
+++ b/frontend/src/components/TemplateManager.jsx
@@ -40,147 +40,151 @@ export default function TemplateManager({ templates, onCreate, onUpdate, onDelet
   };
 
   return (
-    <section className="surface-card space-y-6">
-      <div className="template-manager-header">
-        <h2 className="section-title">Gabarits de synthèse</h2>
-        <button
-          className="btn btn-primary btn-md"
-          type="button"
-          onClick={() => {
-            setError(null);
-            setIsCreating((prev) => {
-              if (prev) {
-                setNewTemplate(emptyTemplate);
-              }
-              return !prev;
-            });
-          }}
-        >
-          {isCreating ? 'Fermer' : 'Créer un gabarit'}
-        </button>
-      </div>
-      {error && <div className="alert alert--error">{error}</div>}
+    <section className="history-stack">
+      <div className="surface-card space-y-6">
+        <div className="template-manager-header">
+          <h2 className="section-title">Gabarits de synthèse</h2>
+          <button
+            className="btn btn-primary btn-md"
+            type="button"
+            onClick={() => {
+              setError(null);
+              setIsCreating((prev) => {
+                if (prev) {
+                  setNewTemplate(emptyTemplate);
+                }
+                return !prev;
+              });
+            }}
+          >
+            {isCreating ? 'Fermer' : 'Créer un gabarit'}
+          </button>
+        </div>
+        {error && <div className="alert alert--error">{error}</div>}
 
-      {isCreating && (
-        <form className="template-form" onSubmit={handleCreate}>
-          <div className="form-field">
-            <label className="form-label" htmlFor="template-name">
-              Nom
-            </label>
-            <input
-              id="template-name"
-              className="input input-bordered"
-              value={newTemplate.name}
-              onChange={(event) => setNewTemplate((prev) => ({ ...prev, name: event.target.value }))}
-              required
-            />
-          </div>
-          <div className="form-field">
-            <label className="form-label" htmlFor="template-description">
-              Description
-            </label>
-            <input
-              id="template-description"
-              className="input input-bordered"
-              value={newTemplate.description}
-              onChange={(event) => setNewTemplate((prev) => ({ ...prev, description: event.target.value }))}
-            />
-          </div>
-          <div className="form-field">
-            <label className="form-label" htmlFor="template-prompt">
-              Prompt
-            </label>
-            <textarea
-              id="template-prompt"
-              className="textarea"
-              value={newTemplate.prompt}
-              onChange={(event) => setNewTemplate((prev) => ({ ...prev, prompt: event.target.value }))}
-              required
-            />
-          </div>
-          <div className="template-actions">
-            <button className="btn btn-primary btn-md" type="submit">
-              Créer
-            </button>
-            <button
-              className="btn btn-secondary btn-md"
-              type="button"
-              onClick={() => {
-                setNewTemplate(emptyTemplate);
-                setIsCreating(false);
-              }}
-            >
-              Annuler
-            </button>
-          </div>
-        </form>
-      )}
+        {isCreating && (
+          <form className="template-form" onSubmit={handleCreate}>
+            <div className="form-field">
+              <label className="form-label" htmlFor="template-name">
+                Nom
+              </label>
+              <input
+                id="template-name"
+                className="input input-bordered"
+                value={newTemplate.name}
+                onChange={(event) => setNewTemplate((prev) => ({ ...prev, name: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="form-field">
+              <label className="form-label" htmlFor="template-description">
+                Description
+              </label>
+              <input
+                id="template-description"
+                className="input input-bordered"
+                value={newTemplate.description}
+                onChange={(event) => setNewTemplate((prev) => ({ ...prev, description: event.target.value }))}
+              />
+            </div>
+            <div className="form-field">
+              <label className="form-label" htmlFor="template-prompt">
+                Prompt
+              </label>
+              <textarea
+                id="template-prompt"
+                className="textarea"
+                value={newTemplate.prompt}
+                onChange={(event) => setNewTemplate((prev) => ({ ...prev, prompt: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="template-actions">
+              <button className="btn btn-primary btn-md" type="submit">
+                Créer
+              </button>
+              <button
+                className="btn btn-secondary btn-md"
+                type="button"
+                onClick={() => {
+                  setNewTemplate(emptyTemplate);
+                  setIsCreating(false);
+                }}
+              >
+                Annuler
+              </button>
+            </div>
+          </form>
+        )}
 
-      <div className="overflow-x-auto">
-        <table className="template-table">
-          <thead>
-            <tr>
-              <th>Nom</th>
-              <th>Description</th>
-              <th>Prompt</th>
-              <th className="template-actions">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sortedTemplates.length === 0 && (
+        <div className="history-table-wrapper">
+          <table className="history-table">
+            <thead>
               <tr>
-                <td className="template-empty" colSpan={4}>
-                  Aucun gabarit n'est disponible pour le moment.
-                </td>
+                <th scope="col">Nom</th>
+                <th scope="col">Description</th>
+                <th scope="col">Prompt</th>
+                <th scope="col">
+                  <span className="sr-only">Actions</span>
+                </th>
               </tr>
-            )}
-            {sortedTemplates.map((template) => (
-              <tr key={template.id} className={editing?.id === template.id ? 'is-editing' : ''}>
-                <td data-label="Nom">{template.name}</td>
-                <td data-label="Description">{template.description || 'Pas de description'}</td>
-                <td data-label="Prompt" className="template-prompt-preview">
-                  <pre>{template.prompt}</pre>
-                </td>
-                <td data-label="Actions" className="template-actions">
-                  <button
-                    className="btn btn-secondary btn-sm"
-                    type="button"
-                    onClick={() => setEditing(template)}
-                  >
-                    Modifier
-                  </button>
-                  <button
-                    className="btn btn-error btn-sm"
-                    type="button"
-                    onClick={async () => {
-                      if (window.confirm(`Supprimer le gabarit "${template.name}" ?`)) {
-                        await onDelete(template.id);
-                      }
-                    }}
-                  >
-                    Supprimer
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {sortedTemplates.length === 0 && (
+                <tr>
+                  <td className="history-empty" colSpan={4}>
+                    Aucun gabarit n'est disponible pour le moment.
+                  </td>
+                </tr>
+              )}
+              {sortedTemplates.map((template) => (
+                <tr key={template.id} className={editing?.id === template.id ? 'is-editing' : ''}>
+                  <td>{template.name}</td>
+                  <td>{template.description || 'Pas de description'}</td>
+                  <td className="template-prompt-preview">
+                    <pre>{template.prompt}</pre>
+                  </td>
+                  <td className="history-table-actions">
+                    <button
+                      className="btn btn-secondary btn-sm"
+                      type="button"
+                      onClick={() => setEditing(template)}
+                    >
+                      Modifier
+                    </button>
+                    <button
+                      className="btn btn-error btn-sm"
+                      type="button"
+                      onClick={async () => {
+                        if (window.confirm(`Supprimer le gabarit "${template.name}" ?`)) {
+                          await onDelete(template.id);
+                        }
+                      }}
+                    >
+                      Supprimer
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
 
-      {editing && (
-        <TemplateEditor
-          key={editing.id}
-          template={editing}
-          onCancel={() => setEditing(null)}
-          onDelete={async () => {
-            if (window.confirm(`Supprimer le gabarit "${editing.name}" ?`)) {
-              await onDelete(editing.id);
-              setEditing(null);
-            }
-          }}
-          onSave={handleUpdate}
-        />
-      )}
+        {editing && (
+          <TemplateEditor
+            key={editing.id}
+            template={editing}
+            onCancel={() => setEditing(null)}
+            onDelete={async () => {
+              if (window.confirm(`Supprimer le gabarit "${editing.name}" ?`)) {
+                await onDelete(editing.id);
+                setEditing(null);
+              }
+            }}
+            onSave={handleUpdate}
+          />
+        )}
+      </div>
     </section>
   );
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -50,50 +50,7 @@
   box-shadow: var(--shadow-soft);
 }
 
-.template-table {
-  width: 100%;
-  border-collapse: collapse;
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  box-shadow: var(--shadow-soft);
-}
-
-.template-table th,
-.template-table td {
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--color-border-subtle);
-  vertical-align: top;
-}
-
-.template-table th {
-  text-align: left;
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  background: var(--color-app-bg);
-}
-
-.template-table th.template-actions {
-  text-align: right;
-}
-
-.template-table tr:last-child td {
-  border-bottom: none;
-}
-
-.template-table tr.is-editing {
-  background: var(--color-app-bg);
-}
-
-.template-table .template-actions {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-}
-
-.template-table .template-prompt-preview pre {
+.template-prompt-preview pre {
   margin: 0;
   max-height: 9rem;
   overflow-y: auto;
@@ -102,46 +59,6 @@
   white-space: pre-wrap;
 }
 
-.template-empty {
-  text-align: center;
-  padding: 2rem 1rem;
-  color: var(--color-text-muted);
-}
-
-@media (max-width: 768px) {
-  .template-table thead {
-    display: none;
-  }
-
-  .template-table tr {
-    display: block;
-    border-bottom: 1px solid var(--color-border-subtle);
-  }
-
-  .template-table tr:last-child {
-    border-bottom: none;
-  }
-
-  .template-table td {
-    display: grid;
-    grid-template-columns: 8rem 1fr;
-    gap: 0.75rem;
-    border: none;
-    padding: 0.85rem 1rem;
-  }
-
-  .template-table td::before {
-    content: attr(data-label);
-    font-weight: 600;
-    color: var(--color-text-muted);
-  }
-
-  .template-table .template-actions {
-    justify-content: flex-start;
-  }
-
-  .template-table td.template-empty {
-    display: block;
-    padding: 1.5rem 1rem;
-  }
+.history-table tr.is-editing {
+  background: var(--color-app-bg);
 }


### PR DESCRIPTION
## Summary
- wrap the template manager card in the shared history stack layout and reuse history table markup
- update the template list headers and actions column to match the job history table semantics
- remove obsolete template table CSS in favor of history styles while keeping prompt previews readable

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d81a3141f88333834f6e9529e988b6