### PR TITLE
Align job detail actions and layout

### DIFF
--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -51,7 +51,7 @@ function formatDuration(startValue, endValue) {
   return parts.join(' ');
 }
 
-export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
+export default function JobDetail({ job, logs, isLoadingLogs }) {
   const [selectedOutput, setSelectedOutput] = useState(null);
   const [isLoadingOutput, setIsLoadingOutput] = useState(false);
   const [outputError, setOutputError] = useState(null);
@@ -186,7 +186,6 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
   }
 
   const progressValue = Math.round(job.progress ?? 0);
-  const isProcessing = job.status === 'queued' || job.status === 'processing';
   const formattedProcessingDuration = useMemo(() => {
     if (!job) {
       return null;
@@ -201,54 +200,41 @@ export default function JobDetail({ job, logs, isLoadingLogs, onDeleteJob }) {
     <div className="history-detail">
       <header className="history-detail-header">
         <div className="history-detail-heading">
-          <div>
+          <div className="history-detail-heading-primary">
             <h2 className="section-title history-detail-title">{job.filename}</h2>
-            <div className="text-base-content/70 text-sm">
-              Déclenché le {new Date(job.createdAt).toLocaleString()} • Dernière mise à jour{' '}
-              {new Date(job.updatedAt).toLocaleString()} • Temps de traitement :{' '}
-              {formattedProcessingDuration ?? '—'}
+            <div className="history-detail-meta text-sm">
+              <span className="history-detail-meta__item">
+                Déclenché le {new Date(job.createdAt).toLocaleString()}
+              </span>
+              <span className="history-detail-meta__item history-detail-meta__processing">
+                <svg
+                  className="history-detail-meta__icon"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  strokeWidth="1.5"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 6v6l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+                  />
+                </svg>
+                <span>
+                  Temps de traitement :{' '}
+                  <strong>{formattedProcessingDuration ?? '—'}</strong>
+                </span>
+              </span>
             </div>
           </div>
-          <button
-            type="button"
-            className="history-delete-btn btn btn-error btn-md btn-with-icon"
-            disabled={isProcessing}
-            onClick={() => {
-              if (isProcessing) {
-                return;
-              }
-              if (
-                window.confirm(
-                  'Voulez-vous vraiment supprimer ce traitement ? Cette action est irréversible.'
-                )
-              ) {
-                onDeleteJob?.(job.id);
-              }
-            }}
-          >
-            <svg
-              className="btn-with-icon__icon"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="1.5"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 7.5h12M9.75 7.5V6.75A1.5 1.5 0 0 1 11.25 5.25h1.5a1.5 1.5 0 0 1 1.5 1.5V7.5m1.5 0V18a1.5 1.5 0 0 1-1.5 1.5h-6a1.5 1.5 0 0 1-1.5-1.5V7.5m3 3v6m3-6v6"
-              />
-            </svg>
-            <span>Supprimer</span>
-          </button>
-        </div>
-        <div className="status-line">
-          <div className="status-actions">
-            <StatusBadge status={job.status} />
-          </div>
-          <div className="status-progress" aria-label="Progression du traitement">
-            <div className="progress-bar" role="presentation">
+          <div className="status-line">
+            <div className="status-actions">
+              <StatusBadge status={job.status} />
+            </div>
+            <div className="status-progress" aria-label="Progression du traitement">
+              <div className="progress-bar" role="presentation">
               <div className="progress-bar__value" style={{ width: `${progressValue}%` }} />
             </div>
             <span className="status-progress-value">{progressValue}%</span>

--- a/frontend/src/pages/JobDetailPage.jsx
+++ b/frontend/src/pages/JobDetailPage.jsx
@@ -130,6 +130,8 @@ export default function JobDetailPage() {
     }
   };
 
+  const isProcessing = job?.status === 'queued' || job?.status === 'processing';
+
   return (
     <section className="history-stack">
       <div className="surface-card history-detail-card">
@@ -137,6 +139,41 @@ export default function JobDetailPage() {
           <Link to="/" className="btn btn-secondary btn-sm">
             Retour à l'historique
           </Link>
+          {job && (
+            <button
+              type="button"
+              className="btn btn-error btn-sm btn-with-icon"
+              disabled={isProcessing}
+              onClick={() => {
+                if (isProcessing) {
+                  return;
+                }
+                const confirmed = window.confirm(
+                  'Voulez-vous vraiment supprimer ce traitement ? Cette action est irréversible.'
+                );
+                if (confirmed) {
+                  void handleDeleteAndReturn(job.id);
+                }
+              }}
+            >
+              <svg
+                className="btn-with-icon__icon"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="1.5"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 7.5h12M9.75 7.5V6.75A1.5 1.5 0 0 1 11.25 5.25h1.5a1.5 1.5 0 0 1 1.5 1.5V7.5m1.5 0V18a1.5 1.5 0 0 1-1.5 1.5h-6a1.5 1.5 0 0 1-1.5-1.5V7.5m3 3v6m3-6v6"
+                />
+              </svg>
+              <span>Supprimer</span>
+            </button>
+          )}
         </div>
         {isLoadingJob ? (
           <p className="text-base-content/70">Chargement du traitement…</p>
@@ -150,7 +187,7 @@ export default function JobDetailPage() {
             </p>
           </div>
         ) : (
-          <JobDetail job={job} logs={logs} isLoadingLogs={isLoadingLogs} onDeleteJob={handleDeleteAndReturn} />
+          <JobDetail job={job} logs={logs} isLoadingLogs={isLoadingLogs} />
         )}
       </div>
     </section>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1027,15 +1027,9 @@ pre {
 .status-line {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-}
-
-@media (min-width: 768px) {
-  .status-line {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
+  align-items: flex-end;
+  gap: 0.75rem;
+  min-width: 12rem;
 }
 
 .status-label {
@@ -1503,38 +1497,55 @@ pre {
 
 .history-detail-toolbar {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
   margin-bottom: 1.5rem;
 }
 
 .history-detail-header {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
   margin-bottom: 1.5rem;
 }
 
 .history-detail-heading {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 1.5rem;
+}
+
+.history-detail-heading-primary {
+  flex: 1 1 18rem;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .history-detail-title {
   margin: 0 0 0.65rem;
 }
 
-.history-delete-btn {
-  flex-shrink: 0;
-  box-shadow: var(--shadow-soft);
+
+.history-detail-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: var(--color-text-muted);
 }
 
-.history-delete-btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
+.history-detail-meta__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.history-detail-meta__icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
 }
 
 .history-detail {
@@ -1864,8 +1875,13 @@ fieldset + fieldset {
     min-width: unset;
   }
 
-  .history-detail-header {
+  .history-detail-heading {
     flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .status-line {
+    width: 100%;
     align-items: flex-start;
   }
 


### PR DESCRIPTION
## Summary
- move the deletion workflow into the job history toolbar so it sits alongside the return action and reuse the existing confirmation flow
- refactor the job detail header to highlight the processing time with an icon, drop the last-update text, and reposition the status badge with its progress bar
- add supporting layout and responsive styles for the new toolbar, metadata row, and status block placement

## Testing
- npm --prefix frontend install *(fails: 403 Forbidden fetching react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68d81f21af488333847402dba53fdfb8