### PR TITLE
Fix JobDetail header markup

### DIFF
--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -235,9 +235,10 @@ export default function JobDetail({ job, logs, isLoadingLogs }) {
             </div>
             <div className="status-progress" aria-label="Progression du traitement">
               <div className="progress-bar" role="presentation">
-              <div className="progress-bar__value" style={{ width: `${progressValue}%` }} />
+                <div className="progress-bar__value" style={{ width: `${progressValue}%` }} />
+              </div>
+              <span className="status-progress-value">{progressValue}%</span>
             </div>
-            <span className="status-progress-value">{progressValue}%</span>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- correct the JobDetail header progress bar markup by nesting the progress value span inside the progress container

## Testing
- npm run build *(fails: vite not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d8225655888333b339e00ed6cfa7a3