### PR TITLE
feat: enhance template manager listing and filtering

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -38,6 +38,18 @@
   flex-wrap: wrap;
 }
 
+.template-manager-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.template-manager-search {
+  min-width: 16rem;
+  flex: 1 1 16rem;
+}
+
 .template-form,
 .template-editor {
   background: var(--color-surface);


### PR DESCRIPTION
## Summary
- add a contextual search field to the template manager header
- filter the template list client-side and surface an empty state when no match is found
- tweak styles so the new search input aligns with existing history table actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81970588c8333a9eac28738c50704