### PR TITLE
feat: reorganize configuration accordion for pipeline options

### DIFF
--- a/frontend/src/components/ConfigPanel.jsx
+++ b/frontend/src/components/ConfigPanel.jsx
@@ -47,6 +47,7 @@ export default function ConfigPanel({ config, onSave }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
+  const [openSection, setOpenSection] = useState('whisper');
 
   useEffect(() => {
     setLocalConfig(config);
@@ -117,6 +118,10 @@ export default function ConfigPanel({ config, onSave }) {
     setClearApiKey((prev) => !prev);
   };
 
+  const toggleSection = (section) => {
+    setOpenSection((prev) => (prev === section ? null : section));
+  };
+
   return (
     <section className="history-stack">
       <div className="surface-card history-detail-card">
@@ -145,179 +150,6 @@ export default function ConfigPanel({ config, onSave }) {
             aria-labelledby={headingId}
             aria-describedby={descriptionId}
           >
-            <section className="history-detail-section" aria-labelledby="config-whisper-heading">
-              <div className="history-detail-section-header">
-                <h3 id="config-whisper-heading" className="history-subtitle">
-                  Whisper local
-                </h3>
-                <p className="history-detail-section-description">
-                  Configurez le modèle exécuté en local pour la transcription.
-                </p>
-              </div>
-              <div className="form-grid">
-                <div className="form-field">
-                  <label className="form-label" htmlFor="whisper-model">
-                    Modèle
-                  </label>
-                  <select
-                    id="whisper-model"
-                    className="select select-bordered"
-                    value={localConfig.whisper.model}
-                    onChange={(event) => updateSection(['whisper', 'model'], event.target.value)}
-                  >
-                    {whisperModels.map((model) => (
-                      <option key={model.name} value={model.name}>
-                        {model.name} - {model.description}
-                      </option>
-                    ))}
-                  </select>
-                  {selectedWhisperModel && (
-                    <p className="form-helper">
-                      {selectedWhisperModel.relativeDuration} • {selectedWhisperModel.sizeInMemory} de mémoire requise
-                    </p>
-                  )}
-                </div>
-                <div className="form-field">
-                  <label className="form-label" htmlFor="whisper-language">
-                    Langue (optionnel)
-                  </label>
-                  <input
-                    id="whisper-language"
-                    className="input input-bordered"
-                    value={localConfig.whisper.language ?? ''}
-                    onChange={(event) => updateSection(['whisper', 'language'], event.target.value)}
-                  />
-                </div>
-                <div className="form-field">
-                  <label className="form-label" htmlFor="whisper-compute">
-                    Type de calcul
-                  </label>
-                  <select
-                    id="whisper-compute"
-                    className="select select-bordered"
-                    value={localConfig.whisper.computeType}
-                    onChange={(event) => updateSection(['whisper', 'computeType'], event.target.value)}
-                  >
-                    {computeTypes.map((option) => (
-                      <option key={option} value={option}>
-                        {option}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="form-field">
-                  <label className="form-label" htmlFor="whisper-batch">
-                    Taille de batch
-                  </label>
-                  <input
-                    id="whisper-batch"
-                    className="input input-bordered"
-                    type="number"
-                    min="0"
-                    value={localConfig.whisper.batchSize ?? 0}
-                    onChange={(event) => updateSection(['whisper', 'batchSize'], Number(event.target.value))}
-                  />
-                </div>
-              </div>
-            </section>
-
-            <section className="history-detail-section" aria-labelledby="config-openai-heading">
-              <div className="history-detail-section-header">
-                <h3 id="config-openai-heading" className="history-subtitle">
-                  OpenAI
-                </h3>
-                <p className="history-detail-section-description">
-                  Paramétrez le modèle de génération de texte et la clé d'accès associée.
-                </p>
-              </div>
-              <div className="form-grid">
-                <div className="form-field">
-                  <label className="form-label" htmlFor="llm-model">
-                    Modèle
-                  </label>
-                  <input
-                    id="llm-model"
-                    className="input input-bordered"
-                    value={localConfig.llm.model}
-                    onChange={(event) => updateSection(['llm', 'model'], event.target.value)}
-                  />
-                </div>
-                <div className="form-field">
-                  <label className="form-label" htmlFor="llm-temperature">
-                    Température
-                  </label>
-                  <input
-                    id="llm-temperature"
-                    className="input input-bordered"
-                    type="number"
-                    step="0.1"
-                    value={localConfig.llm.temperature}
-                    onChange={(event) => updateSection(['llm', 'temperature'], Number(event.target.value))}
-                  />
-                </div>
-                <div className="form-field">
-                  <label className="form-label" htmlFor="llm-max-tokens">
-                    Tokens maximum
-                  </label>
-                  <input
-                    id="llm-max-tokens"
-                    className="input input-bordered"
-                    type="number"
-                    min="1"
-                    value={localConfig.llm.maxOutputTokens}
-                    onChange={(event) => updateSection(['llm', 'maxOutputTokens'], Number(event.target.value))}
-                  />
-                </div>
-                <div className="form-field form-field--full">
-                  <label className="form-label" htmlFor="llm-api-key">
-                    Clé OpenAI
-                  </label>
-                  <input
-                    id="llm-api-key"
-                    className="input input-bordered"
-                    type="password"
-                    value={apiKeyInput}
-                    placeholder={
-                      hasStoredApiKey
-                        ? 'Clé enregistrée — saisir pour remplacer'
-                        : 'Saisissez votre clé OpenAI'
-                    }
-                    onChange={(event) => {
-                      setApiKeyInput(event.target.value);
-                      if (clearApiKey) {
-                        setClearApiKey(false);
-                      }
-                    }}
-                    autoComplete="off"
-                  />
-                  {hasStoredApiKey ? (
-                    <p className="form-helper">
-                      {clearApiKey ? (
-                        <>
-                          La clé enregistrée sera supprimée lors de la sauvegarde.{' '}
-                          <button type="button" className="link-button" onClick={toggleClearApiKey}>
-                            Annuler
-                          </button>
-                          .
-                        </>
-                      ) : (
-                        <>
-                          Une clé est actuellement enregistrée. Laissez le champ vide pour la conserver, saisissez une
-                          nouvelle valeur pour la remplacer ou{' '}
-                          <button type="button" className="link-button" onClick={toggleClearApiKey}>
-                            supprimez la clé
-                          </button>
-                          .
-                        </>
-                      )}
-                    </p>
-                  ) : (
-                    <p className="form-helper">Votre clé sera stockée localement et utilisée uniquement pour la synthèse.</p>
-                  )}
-                </div>
-              </div>
-            </section>
-
             <section className="history-detail-section" aria-labelledby="config-pipeline-heading">
               <div className="history-detail-section-header">
                 <h3 id="config-pipeline-heading" className="history-subtitle">
@@ -359,6 +191,207 @@ export default function ConfigPanel({ config, onSave }) {
                   />
                 </label>
               </div>
+            </section>
+
+            <section
+              className={`history-detail-section history-detail-section--collapsible ${openSection === 'whisper' ? 'is-open' : 'is-collapsed'}`}
+              aria-labelledby="config-whisper-heading"
+            >
+              <button
+                type="button"
+                className="history-detail-section-toggle"
+                aria-expanded={openSection === 'whisper'}
+                aria-controls="config-whisper-content"
+                onClick={() => toggleSection('whisper')}
+              >
+                <div className="history-detail-section-header">
+                  <h3 id="config-whisper-heading" className="history-subtitle">
+                    Whisper local
+                  </h3>
+                  <p className="history-detail-section-description">
+                    Configurez le modèle exécuté en local pour la transcription.
+                  </p>
+                </div>
+                <span className="history-detail-section-toggle-icon" aria-hidden="true" />
+              </button>
+              {openSection === 'whisper' && (
+                <div className="form-grid history-detail-section-body" id="config-whisper-content">
+                  <div className="form-field">
+                    <label className="form-label" htmlFor="whisper-model">
+                      Modèle
+                    </label>
+                    <select
+                      id="whisper-model"
+                      className="select select-bordered"
+                      value={localConfig.whisper.model}
+                      onChange={(event) => updateSection(['whisper', 'model'], event.target.value)}
+                    >
+                      {whisperModels.map((model) => (
+                        <option key={model.name} value={model.name}>
+                          {model.name} - {model.description}
+                        </option>
+                      ))}
+                    </select>
+                    {selectedWhisperModel && (
+                      <p className="form-helper">
+                        {selectedWhisperModel.relativeDuration} • {selectedWhisperModel.sizeInMemory} de mémoire requise
+                      </p>
+                    )}
+                  </div>
+                  <div className="form-field">
+                    <label className="form-label" htmlFor="whisper-language">
+                      Langue (optionnel)
+                    </label>
+                    <input
+                      id="whisper-language"
+                      className="input input-bordered"
+                      value={localConfig.whisper.language ?? ''}
+                      onChange={(event) => updateSection(['whisper', 'language'], event.target.value)}
+                    />
+                  </div>
+                  <div className="form-field">
+                    <label className="form-label" htmlFor="whisper-compute">
+                      Type de calcul
+                    </label>
+                    <select
+                      id="whisper-compute"
+                      className="select select-bordered"
+                      value={localConfig.whisper.computeType}
+                      onChange={(event) => updateSection(['whisper', 'computeType'], event.target.value)}
+                    >
+                      {computeTypes.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="form-field">
+                    <label className="form-label" htmlFor="whisper-batch">
+                      Taille de batch
+                    </label>
+                    <input
+                      id="whisper-batch"
+                      className="input input-bordered"
+                      type="number"
+                      min="0"
+                      value={localConfig.whisper.batchSize ?? 0}
+                      onChange={(event) => updateSection(['whisper', 'batchSize'], Number(event.target.value))}
+                    />
+                  </div>
+                </div>
+              )}
+            </section>
+
+            <section
+              className={`history-detail-section history-detail-section--collapsible ${openSection === 'openai' ? 'is-open' : 'is-collapsed'}`}
+              aria-labelledby="config-openai-heading"
+            >
+              <button
+                type="button"
+                className="history-detail-section-toggle"
+                aria-expanded={openSection === 'openai'}
+                aria-controls="config-openai-content"
+                onClick={() => toggleSection('openai')}
+              >
+                <div className="history-detail-section-header">
+                  <h3 id="config-openai-heading" className="history-subtitle">
+                    OpenAI
+                  </h3>
+                  <p className="history-detail-section-description">
+                    Paramétrez le modèle de génération de texte et la clé d'accès associée.
+                  </p>
+                </div>
+                <span className="history-detail-section-toggle-icon" aria-hidden="true" />
+              </button>
+              {openSection === 'openai' && (
+                <div className="form-grid history-detail-section-body" id="config-openai-content">
+                  <div className="form-field">
+                    <label className="form-label" htmlFor="llm-model">
+                      Modèle
+                    </label>
+                    <input
+                      id="llm-model"
+                      className="input input-bordered"
+                      value={localConfig.llm.model}
+                      onChange={(event) => updateSection(['llm', 'model'], event.target.value)}
+                    />
+                  </div>
+                  <div className="form-field">
+                    <label className="form-label" htmlFor="llm-temperature">
+                      Température
+                    </label>
+                    <input
+                      id="llm-temperature"
+                      className="input input-bordered"
+                      type="number"
+                      step="0.1"
+                      value={localConfig.llm.temperature}
+                      onChange={(event) => updateSection(['llm', 'temperature'], Number(event.target.value))}
+                    />
+                  </div>
+                  <div className="form-field">
+                    <label className="form-label" htmlFor="llm-max-tokens">
+                      Tokens maximum
+                    </label>
+                    <input
+                      id="llm-max-tokens"
+                      className="input input-bordered"
+                      type="number"
+                      min="1"
+                      value={localConfig.llm.maxOutputTokens}
+                      onChange={(event) => updateSection(['llm', 'maxOutputTokens'], Number(event.target.value))}
+                    />
+                  </div>
+                  <div className="form-field form-field--full">
+                    <label className="form-label" htmlFor="llm-api-key">
+                      Clé OpenAI
+                    </label>
+                    <input
+                      id="llm-api-key"
+                      className="input input-bordered"
+                      type="password"
+                      value={apiKeyInput}
+                      placeholder={
+                        hasStoredApiKey
+                          ? 'Clé enregistrée — saisir pour remplacer'
+                          : 'Saisissez votre clé OpenAI'
+                      }
+                      onChange={(event) => {
+                        setApiKeyInput(event.target.value);
+                        if (clearApiKey) {
+                          setClearApiKey(false);
+                        }
+                      }}
+                      autoComplete="off"
+                    />
+                    {hasStoredApiKey ? (
+                      <p className="form-helper">
+                        {clearApiKey ? (
+                          <>
+                            La clé enregistrée sera supprimée lors de la sauvegarde.{' '}
+                            <button type="button" className="link-button" onClick={toggleClearApiKey}>
+                              Annuler
+                            </button>
+                            .
+                          </>
+                        ) : (
+                          <>
+                            Une clé est actuellement enregistrée. Laissez le champ vide pour la conserver, saisissez une
+                            nouvelle valeur pour la remplacer ou{' '}
+                            <button type="button" className="link-button" onClick={toggleClearApiKey}>
+                              supprimez la clé
+                            </button>
+                            .
+                          </>
+                        )}
+                      </p>
+                    ) : (
+                      <p className="form-helper">Votre clé sera stockée localement et utilisée uniquement pour la synthèse.</p>
+                    )}
+                  </div>
+                </div>
+              )}
             </section>
 
             <footer className="history-detail-footer">

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1616,6 +1616,74 @@ pre {
   gap: 1.25rem;
 }
 
+.history-detail-section--collapsible {
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-subtle);
+  gap: 0;
+}
+
+.history-detail-section-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.history-detail-section-toggle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 4px;
+}
+
+.history-detail-section-toggle-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  border: 1px solid var(--color-border-subtle);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.history-detail-section-toggle-icon::before,
+.history-detail-section-toggle-icon::after {
+  content: '';
+  position: absolute;
+  background: var(--color-text-muted);
+  transition: transform 0.2s ease;
+}
+
+.history-detail-section-toggle-icon::before {
+  width: 0.65rem;
+  height: 2px;
+}
+
+.history-detail-section-toggle-icon::after {
+  width: 2px;
+  height: 0.65rem;
+}
+
+.history-detail-section--collapsible.is-open .history-detail-section-toggle-icon::after {
+  transform: scaleY(0);
+}
+
+.history-detail-section--collapsible.is-open .history-detail-section-body {
+  margin-top: 1.5rem;
+}
+
+.history-detail-section--collapsible.is-collapsed .history-detail-section-body {
+  display: none;
+}
+
 .history-detail-section-header {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- move pipeline options to the top of the configuration form
- add an exclusive accordion for the Whisper and OpenAI sections to simplify navigation
- style the collapsible sections with toggle affordances

## Testing
- npm test *(fails: vite not installed because npm install is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82dad793c833398b13fccc5496925